### PR TITLE
Set woody headers only when user is authorized

### DIFF
--- a/src/main/java/dev/vality/wachter/config/WebConfig.java
+++ b/src/main/java/dev/vality/wachter/config/WebConfig.java
@@ -45,7 +45,10 @@ public class WebConfig {
                 woodyFlow.createServiceFork(
                                 () -> {
                                     try {
-                                        addWoodyContext();
+                                        var auth = SecurityContextHolder.getContext().getAuthentication();
+                                        if (auth instanceof JwtAuthenticationToken) {
+                                            addWoodyContext((JwtAuthenticationToken) auth);
+                                        }
                                         setWoodyDeadline(request);
                                         filterChain.doFilter(request, response);
                                     } catch (IOException | ServletException e) {
@@ -69,8 +72,7 @@ public class WebConfig {
         return filterRegistrationBean;
     }
 
-    private void addWoodyContext() {
-        var token = (JwtAuthenticationToken)SecurityContextHolder.getContext().getAuthentication();
+    private void addWoodyContext(JwtAuthenticationToken token) {
         setCustomMetadataValue(UserIdentityIdExtensionKit.KEY, token.getToken().getClaimAsString(JwtClaimNames.SUB));
         setCustomMetadataValue(UserIdentityUsernameExtensionKit.KEY,
                 ((Jwt)token.getPrincipal()).getClaimAsString("preferred_username"));


### PR DESCRIPTION
Ранее была схожая проверка (`if (request.getUserPrincipal() != null)`). При обновлении сервиса решил ее убрать, посчитав избыточной. Просчитался, но первопричину так и не понял, так как воспроизводится только на одном окружении. 
Теперь само условие проверки в коде изменилось, так как поменялось взаимодействие с keycloak-ом. Сам смысл остался тем же.