### PR TITLE
eof fix

### DIFF
--- a/src/main/java/dev/vality/wachter/client/WachterClient.java
+++ b/src/main/java/dev/vality/wachter/client/WachterClient.java
@@ -17,9 +17,10 @@ public record WachterClient(RestClient restClient, WachterRequestFactory request
     public WachterClientResponse send(HttpServletRequest servletRequest, byte[] contentData, String url) {
         var httpMethod = resolveMethod(servletRequest);
         var params = requestFactory.extract(servletRequest);
-        log.info("-> Send request to {} {} | params: {}", httpMethod, url, params);
 
         var headers = requestFactory.buildHeaders(servletRequest);
+
+        log.info("-> Send request to {} {} | params: {}, headers: {}", httpMethod, url, params, headers);
 
         var requestSpec = restClient.method(httpMethod)
                 .uri(url)

--- a/src/main/java/dev/vality/wachter/client/WachterRequestFactory.java
+++ b/src/main/java/dev/vality/wachter/client/WachterRequestFactory.java
@@ -15,7 +15,9 @@ import org.springframework.stereotype.Component;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static dev.vality.wachter.constants.HeadersConstants.*;
@@ -23,6 +25,20 @@ import static dev.vality.woody.api.trace.ContextUtils.getCustomMetadataValue;
 
 @Component
 public class WachterRequestFactory {
+
+    private static final Set<String> SKIPPED_HEADERS = Set.of(
+            HttpHeaders.HOST.toLowerCase(Locale.ROOT),
+            HttpHeaders.CONTENT_LENGTH.toLowerCase(Locale.ROOT),
+            HttpHeaders.TRANSFER_ENCODING.toLowerCase(Locale.ROOT),
+            HttpHeaders.CONNECTION.toLowerCase(Locale.ROOT),
+            HttpHeaders.TE.toLowerCase(Locale.ROOT),
+            "proxy-connection",
+            "keep-alive",
+            "proxy-authenticate",
+            "proxy-authorization",
+            "trailer",
+            "upgrade"
+    );
 
     public HttpHeaders buildHeaders(HttpServletRequest servletRequest) {
         var headers = collectHeaders(servletRequest);
@@ -57,12 +73,19 @@ public class WachterRequestFactory {
         var headerNames = servletRequest.getHeaderNames();
         while (headerNames != null && headerNames.hasMoreElements()) {
             var name = headerNames.nextElement();
+            if (shouldSkipHeader(name)) {
+                continue;
+            }
             var value = servletRequest.getHeader(name);
             if (value != null) {
                 headers.put(name, value);
             }
         }
         return headers;
+    }
+
+    private boolean shouldSkipHeader(String headerName) {
+        return headerName != null && SKIPPED_HEADERS.contains(headerName.toLowerCase(Locale.ROOT));
     }
 
     private void mergeNormalizedWoodyHeaders(HttpServletRequest servletRequest, Map<String, String> headers) {

--- a/src/test/java/dev/vality/wachter/integration/WachterIntegrationTest.java
+++ b/src/test/java/dev/vality/wachter/integration/WachterIntegrationTest.java
@@ -155,4 +155,34 @@ class WachterIntegrationTest extends AbstractKeycloakOpenIdAsWiremockConfig {
         assertEquals(parentId, capturedParentId.get());
         assertEquals(deadline, capturedDeadline.get());
     }
+
+    @Test
+    void shouldStripHopByHopHeadersBeforeProxying() throws Exception {
+        final var deadline = Instant.now().plusSeconds(60);
+        final var payload = TMessageUtil.createTMessage(protocolFactory);
+
+        stubFor(WireMock.post(urlEqualTo("/domain"))
+                .withRequestBody(binaryEqualTo(payload))
+                .willReturn(aResponse()
+                        .withStatus(HttpStatus.OK.value())));
+
+        mockMvc.perform(post("/wachter")
+                        .header("Authorization", "Bearer " + generateSimpleJwtWithRoles())
+                        .header("Service", "Domain")
+                        .header(X_REQUEST_ID, UUID.randomUUID().toString())
+                        .header(X_REQUEST_DEADLINE, deadline.toString())
+                        .header(HttpHeaders.TRANSFER_ENCODING, "chunked")
+                        .header(HttpHeaders.CONNECTION, "keep-alive")
+                        .header(HttpHeaders.TE, "trailers")
+                        .header(HttpHeaders.HOST, "example.org")
+                        .content(payload))
+                .andExpect(status().isOk());
+
+        verify(postRequestedFor(urlEqualTo("/domain"))
+                .withHeader(HttpHeaders.HOST, matching("localhost:\\d+"))
+                .withoutHeader(HttpHeaders.TRANSFER_ENCODING)
+                .withHeader(HttpHeaders.CONNECTION, notMatching("(?i).*keep-alive.*"))
+                .withoutHeader(HttpHeaders.TE)
+                .withRequestBody(binaryEqualTo(payload)));
+    }
 }


### PR DESCRIPTION
Резюме
• Фильтрация заголовков по каждому переходу (включая хост, длину содержимого, кодировку передачи и т. д.) при формировании запросов в восходящем направлении, чтобы RestClient больше не пересылал фрагментированные метаданные, которые нарушают работу реальных вызовов Thrift.

Добавлен интеграционный тест, охватывающий фрагментированные заголовки, чтобы гарантировать их удаление прокси-сервером и корректную передачу полезной нагрузки с помощью хоста.

Анализ первопричины
• Производственные запросы приходили с кодировкой Transfer-Encoding: chunked; мы скопировали этот заголовок в вызов в восходящем направлении при отправке полностью буферизированной полезной нагрузки Thrift, поэтому Dominant попытался декодировать фрагментированное кадрирование из необработанных байтов Thrift, прервал поток, а JDK RestClient сообщил о конце файла (EOF).

Анализ предыдущей конфигурации
• Старая конфигурация Apache HttpClient удаляла исходный заголовок Content-Length, чтобы клиент мог пересчитать его после буферизации тела запроса. • После нашего обновления мы теперь отбрасываем заголовки каждого перехода, включая Content-Length, Transfer-Encoding, Host и т. д., перед пересылкой, поэтому JDK HttpClient автоматически генерирует правильную длину.
• Таким образом, новая фильтрация решает ту же проблему, что и старый [ContentLengthHeaderRemover](https://github.com/valitydev/wachter/pull/71/files#diff-c28f2d79c537aa48cf2cce68683931d00a0032ff3fccd70f9cc8dae7c9e2394eL40) , а проблема EOF возникла из-за пересылки Transfer-Encoding: chunked, а не из-за удаления какого-либо отсутствующего Content-Length.