### PR TITLE
cors fix

### DIFF
--- a/src/main/java/dev/vality/wachter/client/WachterClient.java
+++ b/src/main/java/dev/vality/wachter/client/WachterClient.java
@@ -7,12 +7,20 @@ import org.springframework.http.HttpMethod;
 import org.springframework.util.ObjectUtils;
 import org.springframework.web.client.RestClient;
 
+import java.util.ArrayList;
+import java.util.Locale;
 import java.util.Objects;
+import java.util.Set;
 
 @Slf4j
 public record WachterClient(RestClient restClient, WachterRequestFactory requestFactory) {
 
     private static final byte[] EMPTY_BODY = new byte[0];
+    private static final Set<String> SENSITIVE_HEADERS = Set.of(
+            HttpHeaders.AUTHORIZATION.toLowerCase(Locale.ROOT),
+            HttpHeaders.COOKIE.toLowerCase(Locale.ROOT),
+            HttpHeaders.SET_COOKIE.toLowerCase(Locale.ROOT)
+    );
 
     public WachterClientResponse send(HttpServletRequest servletRequest, byte[] contentData, String url) {
         var httpMethod = resolveMethod(servletRequest);
@@ -20,7 +28,8 @@ public record WachterClient(RestClient restClient, WachterRequestFactory request
 
         var headers = requestFactory.buildHeaders(servletRequest);
 
-        log.info("-> Send request to {} {} | params: {}, headers: {}", httpMethod, url, params, headers);
+        log.info("-> Send request to {} {} | params: {} | headers: {}",
+                httpMethod, url, params, sanitizeHeaders(headers));
 
         var requestSpec = restClient.method(httpMethod)
                 .uri(url)
@@ -38,8 +47,8 @@ public record WachterClient(RestClient restClient, WachterRequestFactory request
             return new WachterClientResponse(status, responseHeaders, responseBody);
         });
 
-        log.info("<- Receive response from {} {} | status: {} | params: {}",
-                httpMethod, url, result.statusCode(), params);
+        log.info("<- Receive response from {} {} | status: {} | params: {} | headers: {}",
+                httpMethod, url, result.statusCode(), params, sanitizeHeaders(result.headers()));
         return result;
     }
 
@@ -49,5 +58,21 @@ public record WachterClient(RestClient restClient, WachterRequestFactory request
         } catch (IllegalArgumentException ex) {
             return HttpMethod.POST;
         }
+    }
+
+    private HttpHeaders sanitizeHeaders(HttpHeaders headers) {
+        var sanitized = new HttpHeaders();
+        headers.forEach((name, values) -> {
+            if (isSensitive(name)) {
+                sanitized.put(name, java.util.List.of("***"));
+            } else {
+                sanitized.put(name, new ArrayList<>(values));
+            }
+        });
+        return sanitized;
+    }
+
+    private boolean isSensitive(String headerName) {
+        return headerName != null && SENSITIVE_HEADERS.contains(headerName.toLowerCase(Locale.ROOT));
     }
 }

--- a/src/main/java/dev/vality/wachter/config/CorsConfig.java
+++ b/src/main/java/dev/vality/wachter/config/CorsConfig.java
@@ -1,0 +1,46 @@
+package dev.vality.wachter.config;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+import org.springframework.beans.factory.annotation.Qualifier;
+
+import java.util.List;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        var configuration = new CorsConfiguration();
+        configuration.setAllowedOriginPatterns(List.of("*"));
+        configuration.setAllowedMethods(List.of(
+                HttpMethod.GET.name(),
+                HttpMethod.HEAD.name(),
+                HttpMethod.POST.name(),
+                HttpMethod.PUT.name(),
+                HttpMethod.DELETE.name(),
+                HttpMethod.OPTIONS.name()
+        ));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowCredentials(true);
+        configuration.setMaxAge(1800L);
+
+        var source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+
+    @Bean
+    public FilterRegistrationBean<CorsFilter> corsFilterRegistration(
+            @Qualifier("corsConfigurationSource") CorsConfigurationSource source) {
+        var registrationBean = new FilterRegistrationBean<>(new CorsFilter(source));
+        registrationBean.setOrder(-102);
+        return registrationBean;
+    }
+}

--- a/src/main/java/dev/vality/wachter/config/SecurityConfig.java
+++ b/src/main/java/dev/vality/wachter/config/SecurityConfig.java
@@ -11,9 +11,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @EnableWebSecurity
@@ -22,6 +20,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 public class SecurityConfig {
 
     private final JwtAuthConverter jwtAuthConverter;
+    private final CorsConfigurationSource corsConfigurationSource;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -35,18 +34,7 @@ public class SecurityConfig {
                         .anyRequest().authenticated());
         http.oauth2ResourceServer(server -> server.jwt(token -> token.jwtAuthenticationConverter(jwtAuthConverter)));
         http.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
-        http.cors(c -> c.configurationSource(corsConfigurationSource()));
+        http.cors(c -> c.configurationSource(corsConfigurationSource));
         return http.build();
-    }
-
-    public CorsConfigurationSource corsConfigurationSource() {
-        CorsConfiguration configuration = new CorsConfiguration();
-        configuration.applyPermitDefaultValues();
-        configuration.addAllowedMethod(HttpMethod.PUT);
-        configuration.addAllowedMethod(HttpMethod.DELETE);
-        configuration.addAllowedMethod(HttpMethod.OPTIONS);
-        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/**", configuration);
-        return source;
     }
 }

--- a/src/test/java/dev/vality/wachter/integration/WachterIntegrationTest.java
+++ b/src/test/java/dev/vality/wachter/integration/WachterIntegrationTest.java
@@ -190,7 +190,7 @@ class WachterIntegrationTest extends AbstractKeycloakOpenIdAsWiremockConfig {
     void shouldReturnCorsHeadersOnSuccessfulResponse() throws Exception {
         final var deadline = Instant.now().plusSeconds(120);
         final var payload = TMessageUtil.createTMessage(protocolFactory);
-        final var origin = "https://iddqd.empayre.com";
+        final var origin = "https://iddqd.valitydev.com";
 
         stubFor(WireMock.post(urlEqualTo("/domain"))
                 .withRequestBody(binaryEqualTo(payload))
@@ -215,7 +215,7 @@ class WachterIntegrationTest extends AbstractKeycloakOpenIdAsWiremockConfig {
     void shouldReturnCorsHeadersOnErrorResponse() throws Exception {
         final var deadline = Instant.now().plusSeconds(120);
         final var payload = TMessageUtil.createTMessage(protocolFactory);
-        final var origin = "https://iddqd.empayre.com";
+        final var origin = "https://iddqd.valitydev.com";
 
         stubFor(WireMock.post(urlEqualTo("/domain"))
                 .withRequestBody(binaryEqualTo(payload))

--- a/src/test/java/dev/vality/wachter/integration/WachterIntegrationTest.java
+++ b/src/test/java/dev/vality/wachter/integration/WachterIntegrationTest.java
@@ -185,4 +185,54 @@ class WachterIntegrationTest extends AbstractKeycloakOpenIdAsWiremockConfig {
                 .withoutHeader(HttpHeaders.TE)
                 .withRequestBody(binaryEqualTo(payload)));
     }
+
+    @Test
+    void shouldReturnCorsHeadersOnSuccessfulResponse() throws Exception {
+        final var deadline = Instant.now().plusSeconds(120);
+        final var payload = TMessageUtil.createTMessage(protocolFactory);
+        final var origin = "https://iddqd.empayre.com";
+
+        stubFor(WireMock.post(urlEqualTo("/domain"))
+                .withRequestBody(binaryEqualTo(payload))
+                .willReturn(aResponse()
+                        .withStatus(HttpStatus.OK.value())));
+
+        mockMvc.perform(post("/wachter")
+                        .header("Authorization", "Bearer " + generateSimpleJwtWithRoles())
+                        .header("Service", "Domain")
+                        .header(X_REQUEST_ID, UUID.randomUUID().toString())
+                        .header(X_REQUEST_DEADLINE, deadline.toString())
+                        .header(HttpHeaders.ORIGIN, origin)
+                        .content(payload))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.header()
+                        .string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, origin))
+                .andExpect(MockMvcResultMatchers.header()
+                        .string(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS, "true"));
+    }
+
+    @Test
+    void shouldReturnCorsHeadersOnErrorResponse() throws Exception {
+        final var deadline = Instant.now().plusSeconds(120);
+        final var payload = TMessageUtil.createTMessage(protocolFactory);
+        final var origin = "https://iddqd.empayre.com";
+
+        stubFor(WireMock.post(urlEqualTo("/domain"))
+                .withRequestBody(binaryEqualTo(payload))
+                .willReturn(aResponse()
+                        .withStatus(HttpStatus.BAD_GATEWAY.value())));
+
+        mockMvc.perform(post("/wachter")
+                        .header("Authorization", "Bearer " + generateSimpleJwtWithRoles())
+                        .header("Service", "Domain")
+                        .header(X_REQUEST_ID, UUID.randomUUID().toString())
+                        .header(X_REQUEST_DEADLINE, deadline.toString())
+                        .header(HttpHeaders.ORIGIN, origin)
+                        .content(payload))
+                .andExpect(status().isBadGateway())
+                .andExpect(MockMvcResultMatchers.header()
+                        .string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, origin))
+                .andExpect(MockMvcResultMatchers.header()
+                        .string(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS, "true"));
+    }
 }


### PR DESCRIPTION
🙂
Previously (Apache HttpClient), the proxy used RestTemplate, which returned upstream responses without triggering an error dispatch, so the CORS headers were preserved.

>  то есть это произошло из за специфики RestClient?

⛬  Да. Переход на RestClient (на JDK HTTP-клиенте) изменил поведение при обрыве соединения: вместо
   “нормального” ответа он бросает ResourceAccessException, из-за чего запрос переключается в
   error-диспетчеризацию и стандартный http.cors(...) уже не проставляет заголовки. Поэтому нам и
   понадобился отдельный CorsFilter, чтобы headers добавлялись даже на ошибочных ответах.

>  щас все в порядке стало?

⛬  Да. С добавленным CorsFilter CORS‑заголовки возвращаются и на успешные, и на ошибочные ответы;
   интеграционные тесты это подтверждают (shouldReturnCorsHeadersOnErrorResponse), и реальная проблема
   “Missing Allow Origin” исчезла.
<img width="1588" height="398" alt="image" src="https://github.com/user-attachments/assets/8f8ac3c0-36b7-469e-b25d-575646b03bab" />
