### PR TITLE
fix woody thrown, add ProxyHeadersExtractor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>wachter</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.0</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -140,9 +140,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-contract-wiremock</artifactId>
-            <version>4.1.0</version>
+            <groupId>org.wiremock.integrations</groupId>
+            <artifactId>wiremock-spring-boot</artifactId>
+            <version>3.10.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/dev/vality/wachter/client/ProxyHeadersExtractor.java
+++ b/src/main/java/dev/vality/wachter/client/ProxyHeadersExtractor.java
@@ -1,0 +1,94 @@
+package dev.vality.wachter.client;
+
+import dev.vality.wachter.constants.TraceHeadersConstants;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.experimental.UtilityClass;
+import org.springframework.http.HttpHeaders;
+import org.springframework.util.StringUtils;
+
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@UtilityClass
+public class ProxyHeadersExtractor {
+
+    private static final Set<String> HOP_BY_HOP_HEADERS = Stream.of(
+            HttpHeaders.CONNECTION,
+            HttpHeaders.PROXY_AUTHENTICATE,
+            HttpHeaders.PROXY_AUTHORIZATION,
+            HttpHeaders.TE,
+            HttpHeaders.TRAILER,
+            HttpHeaders.TRANSFER_ENCODING,
+            HttpHeaders.UPGRADE,
+            "keep-alive",
+            "proxy-connection"
+    ).map(header -> header.toLowerCase(Locale.ROOT)).collect(Collectors.toSet());
+
+    private static final Set<String> EXCLUDED_HEADERS = Stream.of(
+            HttpHeaders.AUTHORIZATION,
+            HttpHeaders.CONTENT_LENGTH,
+            HttpHeaders.HOST,
+            HttpHeaders.COOKIE,
+            HttpHeaders.SET_COOKIE,
+            HttpHeaders.SET_COOKIE2,
+            HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD,
+            HttpHeaders.ACCESS_CONTROL_REQUEST_HEADERS,
+            HttpHeaders.CACHE_CONTROL,
+            HttpHeaders.PRAGMA,
+            HttpHeaders.ORIGIN,
+            HttpHeaders.REFERER,
+            "dnt",
+            "priority",
+            "service",
+            TraceHeadersConstants.OTEL_TRACE_PARENT,
+            TraceHeadersConstants.X_REQUEST_ID,
+            TraceHeadersConstants.X_REQUEST_DEADLINE
+    ).map(header -> header.toLowerCase(Locale.ROOT)).collect(Collectors.toSet());
+
+    private static final List<String> EXCLUDED_PREFIXES = List.of(
+            "cf-",
+            "cdn-",
+            "sec-",
+            TraceHeadersConstants.WOODY_PREFIX,
+            TraceHeadersConstants.X_WOODY_PREFIX
+    );
+
+    public HttpHeaders extractHeaders(HttpServletRequest request) {
+        var collected = new HttpHeaders();
+        var headerNames = request.getHeaderNames();
+        if (headerNames == null) {
+            return collected;
+        }
+        while (headerNames.hasMoreElements()) {
+            var headerName = headerNames.nextElement();
+            var lowerCaseName = headerName.toLowerCase(Locale.ROOT);
+            if (shouldSkip(lowerCaseName)) {
+                continue;
+            }
+            var values = request.getHeaders(headerName);
+            while (values.hasMoreElements()) {
+                var value = values.nextElement();
+                if (StringUtils.hasText(value)) {
+                    collected.add(headerName, value);
+                }
+            }
+        }
+        return collected;
+    }
+
+    private boolean shouldSkip(String lowerCaseHeaderName) {
+        if (HOP_BY_HOP_HEADERS.contains(lowerCaseHeaderName) || EXCLUDED_HEADERS.contains(lowerCaseHeaderName)) {
+            return true;
+        }
+        for (var prefix : EXCLUDED_PREFIXES) {
+            if (lowerCaseHeaderName.startsWith(prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/dev/vality/wachter/client/WachterClient.java
+++ b/src/main/java/dev/vality/wachter/client/WachterClient.java
@@ -55,19 +55,6 @@ public class WachterClient {
         });
     }
 
-    private LinkedHashMap<String, Object> getLoggedHeaders(HttpHeaders proxyHeaders,
-                                                           Map<String, String> traceHeaders) {
-        var loggedHeaders = new LinkedHashMap<String, Object>();
-        proxyHeaders.forEach((name, values) -> {
-            if (values == null || values.isEmpty()) {
-                return;
-            }
-            loggedHeaders.put(name, values.size() == 1 ? values.getFirst() : values);
-        });
-        loggedHeaders.putAll(traceHeaders);
-        return loggedHeaders;
-    }
-
     private HttpMethod resolveMethod(HttpServletRequest servletRequest) {
         try {
             return HttpMethod.valueOf(servletRequest.getMethod());

--- a/src/main/java/dev/vality/wachter/client/WachterClient.java
+++ b/src/main/java/dev/vality/wachter/client/WachterClient.java
@@ -5,12 +5,16 @@ import dev.vality.wachter.tracing.TraceContextHeadersNormalizer;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
 import org.springframework.util.ObjectUtils;
 import org.springframework.web.client.RestClient;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Objects;
+import java.util.function.Consumer;
 
 @Slf4j
 @Component
@@ -24,13 +28,18 @@ public class WachterClient {
     public WachterClientResponse send(HttpServletRequest servletRequest, byte[] contentData, String url) {
         var httpMethod = resolveMethod(servletRequest);
 
-        var headers = TraceContextHeadersExtractor.extractHeaders();
+        var proxyHeaders = ProxyHeadersExtractor.extractHeaders(servletRequest);
+        var traceHeaders = TraceContextHeadersExtractor.extractHeaders();
 
-        log.info("-> Send request to {} {} | headers: {}", httpMethod, url, headers);
+        var httpHeaders = new HttpHeaders();
+        proxyHeaders.forEach(httpHeaders::addAll);
+        traceHeaders.forEach(httpHeaders::set);
+
+        log.info("-> Send request to {} {} | headers: {}", httpMethod, url, httpHeaders);
 
         var requestSpec = restClient.method(httpMethod)
                 .uri(url)
-                .headers(httpHeaders -> headers.forEach(httpHeaders::set));
+                .headers(h -> h.addAll(httpHeaders));
 
         if (!ObjectUtils.isEmpty(contentData)) {
             requestSpec = requestSpec.body(contentData);
@@ -44,6 +53,19 @@ public class WachterClient {
             var responseHeaders = TraceContextHeadersNormalizer.normalizeResponseHeaders(response.getHeaders());
             return new WachterClientResponse(status, responseHeaders, responseBody);
         });
+    }
+
+    private LinkedHashMap<String, Object> getLoggedHeaders(HttpHeaders proxyHeaders,
+                                                           Map<String, String> traceHeaders) {
+        var loggedHeaders = new LinkedHashMap<String, Object>();
+        proxyHeaders.forEach((name, values) -> {
+            if (values == null || values.isEmpty()) {
+                return;
+            }
+            loggedHeaders.put(name, values.size() == 1 ? values.getFirst() : values);
+        });
+        loggedHeaders.putAll(traceHeaders);
+        return loggedHeaders;
     }
 
     private HttpMethod resolveMethod(HttpServletRequest servletRequest) {

--- a/src/main/java/dev/vality/wachter/client/WachterClient.java
+++ b/src/main/java/dev/vality/wachter/client/WachterClient.java
@@ -1,7 +1,7 @@
 package dev.vality.wachter.client;
 
-import dev.vality.wachter.config.tracing.TraceContextHeadersExtractor;
-import dev.vality.wachter.config.tracing.TraceContextHeadersNormalizer;
+import dev.vality.wachter.tracing.TraceContextHeadersExtractor;
+import dev.vality.wachter.tracing.TraceContextHeadersNormalizer;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/dev/vality/wachter/config/WebConfig.java
+++ b/src/main/java/dev/vality/wachter/config/WebConfig.java
@@ -1,6 +1,6 @@
 package dev.vality.wachter.config;
 
-import dev.vality.wachter.config.tracing.WoodyTracingFilter;
+import dev.vality.wachter.tracing.WoodyTracingFilter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/dev/vality/wachter/constants/TraceHeadersConstants.java
+++ b/src/main/java/dev/vality/wachter/constants/TraceHeadersConstants.java
@@ -1,6 +1,6 @@
 package dev.vality.wachter.constants;
 
-public class HeadersConstants {
+public class TraceHeadersConstants {
 
     public static final String X_REQUEST_ID = "X-Request-ID";
     public static final String X_REQUEST_DEADLINE = "X-Request-Deadline";

--- a/src/main/java/dev/vality/wachter/constants/TraceHeadersConstants.java
+++ b/src/main/java/dev/vality/wachter/constants/TraceHeadersConstants.java
@@ -11,7 +11,8 @@ public class TraceHeadersConstants {
     public static final String X_WOODY_DEADLINE = X_WOODY_PREFIX + "deadline";
     public static final String X_WOODY_ERROR_CLASS = X_WOODY_PREFIX + "error-class";
     public static final String X_WOODY_ERROR_REASON = X_WOODY_PREFIX + "error-reason";
-    public static final String X_WOODY_META_USER_IDENTITY_PREFIX = X_WOODY_PREFIX + WoodySuffixes.META_USER_IDENTITY;
+    public static final String X_WOODY_META_USER_IDENTITY_PREFIX =
+            X_WOODY_PREFIX + WoodySuffixes.META_USER_IDENTITY_SUFFIX;
     public static final String WOODY_PREFIX = "woody.";
     public static final String WOODY_TRACE_ID = WOODY_PREFIX + "trace-id";
     public static final String WOODY_SPAN_ID = WOODY_PREFIX + "span-id";
@@ -19,7 +20,10 @@ public class TraceHeadersConstants {
     public static final String WOODY_DEADLINE = WOODY_PREFIX + "deadline";
     public static final String WOODY_ERROR_CLASS = WOODY_PREFIX + "error-class";
     public static final String WOODY_ERROR_REASON = WOODY_PREFIX + "error-reason";
-    public static final String WOODY_META_USER_IDENTITY_PREFIX = WOODY_PREFIX + WoodySuffixes.META_USER_IDENTITY_DOT;
+    public static final String WOODY_META_USER_IDENTITY_PREFIX =
+            WOODY_PREFIX + WoodySuffixes.META_USER_IDENTITY_DOT_SUFFIX;
+    public static final String WOODY_META_REQUEST_ID = WOODY_META_USER_IDENTITY_PREFIX + "x-request-id";
+    public static final String WOODY_META_REQUEST_DEADLINE = WOODY_META_USER_IDENTITY_PREFIX + "x-request-deadline";
     public static final String OTEL_TRACE_PARENT = "traceparent";
 
     public static final class WoodySuffixes {
@@ -28,9 +32,9 @@ public class TraceHeadersConstants {
         private static final String HYPHEN = "-";
         private static final String DOT = ".";
 
-        public static final String META_USER_IDENTITY = META + HYPHEN + USER_IDENTITY + HYPHEN;
-        public static final String META_USER_IDENTITY_DOT = META + DOT + USER_IDENTITY + DOT;
-        public static final String USER_IDENTITY_KEY_PREFIX = USER_IDENTITY + DOT;
+        public static final String META_USER_IDENTITY_SUFFIX = META + HYPHEN + USER_IDENTITY + HYPHEN;
+        public static final String META_USER_IDENTITY_DOT_SUFFIX = META + DOT + USER_IDENTITY + DOT;
+        public static final String USER_IDENTITY_KEY_SUFFIX = USER_IDENTITY + DOT;
 
         private WoodySuffixes() {
         }
@@ -39,8 +43,8 @@ public class TraceHeadersConstants {
             if (extensionKey == null || extensionKey.isEmpty()) {
                 return "";
             }
-            if (extensionKey.startsWith(USER_IDENTITY_KEY_PREFIX)) {
-                return extensionKey.substring(USER_IDENTITY_KEY_PREFIX.length());
+            if (extensionKey.startsWith(USER_IDENTITY_KEY_SUFFIX)) {
+                return extensionKey.substring(USER_IDENTITY_KEY_SUFFIX.length());
             }
             int lastDot = extensionKey.lastIndexOf('.');
             return lastDot >= 0 ? extensionKey.substring(lastDot + 1) : extensionKey;

--- a/src/main/java/dev/vality/wachter/constants/TraceHeadersConstants.java
+++ b/src/main/java/dev/vality/wachter/constants/TraceHeadersConstants.java
@@ -9,12 +9,16 @@ public class TraceHeadersConstants {
     public static final String X_WOODY_SPAN_ID = X_WOODY_PREFIX + "span-id";
     public static final String X_WOODY_PARENT_ID = X_WOODY_PREFIX + "parent-id";
     public static final String X_WOODY_DEADLINE = X_WOODY_PREFIX + "deadline";
+    public static final String X_WOODY_ERROR_CLASS = X_WOODY_PREFIX + "error-class";
+    public static final String X_WOODY_ERROR_REASON = X_WOODY_PREFIX + "error-reason";
     public static final String X_WOODY_META_USER_IDENTITY_PREFIX = X_WOODY_PREFIX + WoodySuffixes.META_USER_IDENTITY;
     public static final String WOODY_PREFIX = "woody.";
     public static final String WOODY_TRACE_ID = WOODY_PREFIX + "trace-id";
     public static final String WOODY_SPAN_ID = WOODY_PREFIX + "span-id";
     public static final String WOODY_PARENT_ID = WOODY_PREFIX + "parent-id";
     public static final String WOODY_DEADLINE = WOODY_PREFIX + "deadline";
+    public static final String WOODY_ERROR_CLASS = WOODY_PREFIX + "error-class";
+    public static final String WOODY_ERROR_REASON = WOODY_PREFIX + "error-reason";
     public static final String WOODY_META_USER_IDENTITY_PREFIX = WOODY_PREFIX + WoodySuffixes.META_USER_IDENTITY_DOT;
     public static final String OTEL_TRACE_PARENT = "traceparent";
 

--- a/src/main/java/dev/vality/wachter/tracing/TraceContextHeadersExtractor.java
+++ b/src/main/java/dev/vality/wachter/tracing/TraceContextHeadersExtractor.java
@@ -57,7 +57,8 @@ public class TraceContextHeadersExtractor {
             return;
         }
 
-        putMetadataValue(headers, customMetadata, WOODY_META_USER_IDENTITY_PREFIX + suffix);
+        var value = (String) customMetadata.getValue(extensionKey);
+        putIfNotNull(headers, WOODY_META_USER_IDENTITY_PREFIX + suffix, value);
     }
 
     private void putMetadataValue(Map<String, String> headers, Metadata customMetadata, String key) {

--- a/src/main/java/dev/vality/wachter/tracing/TraceContextHeadersExtractor.java
+++ b/src/main/java/dev/vality/wachter/tracing/TraceContextHeadersExtractor.java
@@ -1,4 +1,4 @@
-package dev.vality.wachter.config.tracing;
+package dev.vality.wachter.tracing;
 
 import dev.vality.woody.api.trace.Metadata;
 import dev.vality.woody.api.trace.context.TraceContext;
@@ -17,7 +17,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
-import static dev.vality.wachter.constants.HeadersConstants.*;
+import static dev.vality.wachter.constants.TraceHeadersConstants.*;
 
 @Slf4j
 @UtilityClass

--- a/src/main/java/dev/vality/wachter/tracing/TraceContextHeadersExtractor.java
+++ b/src/main/java/dev/vality/wachter/tracing/TraceContextHeadersExtractor.java
@@ -46,8 +46,8 @@ public class TraceContextHeadersExtractor {
         extractUserIdentityHeader(headers, customMetadata, UserIdentityUsernameExtensionKit.KEY);
         extractUserIdentityHeader(headers, customMetadata, UserIdentityEmailExtensionKit.KEY);
         extractUserIdentityHeader(headers, customMetadata, UserIdentityRealmExtensionKit.KEY);
-        putMetadataValue(headers, customMetadata, X_REQUEST_ID);
-        putMetadataValue(headers, customMetadata, X_REQUEST_DEADLINE);
+        putMetadataValue(headers, customMetadata, X_REQUEST_ID, WOODY_META_REQUEST_ID);
+        putMetadataValue(headers, customMetadata, X_REQUEST_DEADLINE, WOODY_META_REQUEST_DEADLINE);
         return headers;
     }
 
@@ -61,9 +61,12 @@ public class TraceContextHeadersExtractor {
         putIfNotNull(headers, WOODY_META_USER_IDENTITY_PREFIX + suffix, value);
     }
 
-    private void putMetadataValue(Map<String, String> headers, Metadata customMetadata, String key) {
-        var value = (String) customMetadata.getValue(key);
-        putIfNotNull(headers, key, value);
+    private void putMetadataValue(Map<String, String> headers,
+                                  Metadata customMetadata,
+                                  String metadataKey,
+                                  String headerKey) {
+        var value = (String) customMetadata.getValue(metadataKey);
+        putIfNotNull(headers, headerKey, value);
     }
 
     private void putIfNotNull(Map<String, String> headers,

--- a/src/main/java/dev/vality/wachter/tracing/TraceContextHeadersNormalizer.java
+++ b/src/main/java/dev/vality/wachter/tracing/TraceContextHeadersNormalizer.java
@@ -100,11 +100,16 @@ public class TraceContextHeadersNormalizer {
     private void mergeRequestDeadline(HttpServletRequest request, Map<String, String> headers) {
         var requestDeadlineHeader = request.getHeader(X_REQUEST_DEADLINE);
         var requestIdHeader = request.getHeader(X_REQUEST_ID);
+        if (requestIdHeader != null && !requestIdHeader.isEmpty()) {
+            headers.put(X_REQUEST_ID, requestIdHeader);
+        }
         if (requestDeadlineHeader == null) {
             return;
         }
         try {
-            headers.putIfAbsent(WOODY_DEADLINE, getInstant(requestDeadlineHeader, requestIdHeader).toString());
+            var normalizedDeadline = getInstant(requestDeadlineHeader, requestIdHeader).toString();
+            headers.putIfAbsent(WOODY_DEADLINE, normalizedDeadline);
+            headers.put(X_REQUEST_DEADLINE, normalizedDeadline);
         } catch (Exception e) {
             log.warn("Unable to parse 'X-Request-Deadline' header value '{}'", requestDeadlineHeader);
         }

--- a/src/main/java/dev/vality/wachter/tracing/TraceContextHeadersNormalizer.java
+++ b/src/main/java/dev/vality/wachter/tracing/TraceContextHeadersNormalizer.java
@@ -32,6 +32,7 @@ public class TraceContextHeadersNormalizer {
         }
         mergeJwtIntoHeaders(normalized);
         mergeRequestDeadline(request, normalized);
+        mergeWoodyRequestMetadata(normalized);
         return normalized.isEmpty() ? Map.of() : Map.copyOf(normalized);
     }
 
@@ -66,8 +67,8 @@ public class TraceContextHeadersNormalizer {
                 headers.put(lowerCase, value);
             } else {
                 var suffix = lowerCase.substring(X_WOODY_PREFIX.length());
-                if (suffix.startsWith(WoodySuffixes.META_USER_IDENTITY)) {
-                    var metaKey = suffix.substring(WoodySuffixes.META_USER_IDENTITY.length());
+                if (suffix.startsWith(WoodySuffixes.META_USER_IDENTITY_SUFFIX)) {
+                    var metaKey = suffix.substring(WoodySuffixes.META_USER_IDENTITY_SUFFIX.length());
                     headers.put(WOODY_META_USER_IDENTITY_PREFIX + metaKey, value);
                 } else {
                     headers.put(WOODY_PREFIX + suffix, value);
@@ -115,6 +116,18 @@ public class TraceContextHeadersNormalizer {
         }
     }
 
+    private void mergeWoodyRequestMetadata(Map<String, String> headers) {
+        var woodyRequestId = headers.get(WOODY_META_REQUEST_ID);
+        if (woodyRequestId != null && !woodyRequestId.isEmpty()) {
+            headers.put(X_REQUEST_ID, woodyRequestId);
+        }
+        var woodyDeadline = headers.get(WOODY_META_REQUEST_DEADLINE);
+        if (woodyDeadline != null && !woodyDeadline.isEmpty()) {
+            headers.put(X_REQUEST_DEADLINE, woodyDeadline);
+            headers.putIfAbsent(WOODY_DEADLINE, woodyDeadline);
+        }
+    }
+
     private void putJwtMetadata(Map<String, String> headers, String extensionKey, String value) {
         var suffix = WoodySuffixes.userIdentitySuffix(extensionKey);
         if (suffix.isEmpty() || value == null || value.isEmpty()) {
@@ -140,9 +153,15 @@ public class TraceContextHeadersNormalizer {
             headers.addAll(lowerCase, values);
         } else {
             var suffix = lowerCase.substring(WOODY_PREFIX.length());
-            if (suffix.startsWith(WoodySuffixes.META_USER_IDENTITY_DOT)) {
-                var metaKey = suffix.substring(WoodySuffixes.META_USER_IDENTITY_DOT.length());
+            if (suffix.startsWith(WoodySuffixes.META_USER_IDENTITY_DOT_SUFFIX)) {
+                var metaKey = suffix.substring(WoodySuffixes.META_USER_IDENTITY_DOT_SUFFIX.length());
                 headers.addAll(X_WOODY_META_USER_IDENTITY_PREFIX + metaKey, values);
+                var metaKeyLower = metaKey.toLowerCase(Locale.ROOT);
+                if (metaKeyLower.equals("x-request-id")) {
+                    headers.addAll(X_REQUEST_ID, values);
+                } else if (metaKeyLower.equals("x-request-deadline")) {
+                    headers.addAll(X_REQUEST_DEADLINE, values);
+                }
             } else {
                 headers.addAll(X_WOODY_PREFIX + suffix, values);
             }

--- a/src/main/java/dev/vality/wachter/tracing/TraceContextHeadersNormalizer.java
+++ b/src/main/java/dev/vality/wachter/tracing/TraceContextHeadersNormalizer.java
@@ -1,4 +1,4 @@
-package dev.vality.wachter.config.tracing;
+package dev.vality.wachter.tracing;
 
 import dev.vality.wachter.security.JwtTokenDetailsExtractor;
 import dev.vality.woody.api.trace.context.metadata.user.UserIdentityEmailExtensionKit;
@@ -15,7 +15,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
 
-import static dev.vality.wachter.constants.HeadersConstants.*;
+import static dev.vality.wachter.constants.TraceHeadersConstants.*;
 import static dev.vality.wachter.utils.DeadlineUtil.*;
 
 @Slf4j

--- a/src/main/java/dev/vality/wachter/tracing/TraceContextRestorer.java
+++ b/src/main/java/dev/vality/wachter/tracing/TraceContextRestorer.java
@@ -1,4 +1,4 @@
-package dev.vality.wachter.config.tracing;
+package dev.vality.wachter.tracing;
 
 import dev.vality.woody.api.flow.WFlow;
 import dev.vality.woody.api.trace.TraceData;
@@ -18,7 +18,7 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.function.Consumer;
 
-import static dev.vality.wachter.constants.HeadersConstants.*;
+import static dev.vality.wachter.constants.TraceHeadersConstants.*;
 
 @Slf4j
 @UtilityClass

--- a/src/main/java/dev/vality/wachter/tracing/WoodyTracingFilter.java
+++ b/src/main/java/dev/vality/wachter/tracing/WoodyTracingFilter.java
@@ -1,4 +1,4 @@
-package dev.vality.wachter.config.tracing;
+package dev.vality.wachter.tracing;
 
 import dev.vality.woody.api.flow.WFlow;
 import jakarta.servlet.FilterChain;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,48 +49,84 @@ wachter:
     enabled: true
   serviceHeader: Service
   services:
+    Accounter:
+      name: Accounter
+      url: http://shumway:8022/accounter
     ClaimManagement:
       name: ClaimManagement
-      url: http://localhost:8097/v1/cm
+      url: http://claim-management:8022/v1/cm
     DepositManagement:
       name: DepositManagement
-      url: http://localhost:8022/v1/deposit
+      url: http://fistful:8022/v1/deposit
     Domain:
       name: Domain
-      url: http://localhost:8022/v1/domain/repository
+      url: http://dominant:8022/v1/domain/repository
+    RepositoryClient:
+      name: RepositoryClient
+      url: http://dominant:8022/v1/domain/repository_client
     DominantCache:
       name: DominantCache
-      url: http://localhost:8022/v1/dominant/cache
+      url: http://dominant-cache:8022/v1/dominant/cache
     FileStorage:
       name: FileStorage
-      url: http://localhost:8022/file_storage
+      url: http://file-storage-v2:8022/file_storage/v2
     FistfulStatistics:
       name: FistfulStatistics
-      url: http://localhost:8022/fistful/stat
+      url: http://fistful-magista:8022/stat
     MerchantStatistics:
       name: MerchantStatistics
-      url: http://localhost:8022/v3/stat
-    Messages:
-      name: Messages
-      url: http://localhost:8097/v1/messages
+      url: http://magista:8022/v3/stat
     Invoicing:
       name: Invoicing
-      url: http://localhost:8097/v1/processing/invoicin
+      url: http://hellgate:8022/v1/processing/invoicing
     PartyManagement:
       name: PartyManagement
-      url: http://localhost:8097/v1/processing/partymgmt
+      url: http://party-management:8022/v1/processing/partymgmt
     PayoutManagement:
       name: PayoutManagement
-      url: http://localhost:8097/payout/management
+      url: http://payout-manager:8022/payout/management
     RepairManagement:
       name: repairManagement
-      url: http://localhost:8097/v1/repair
+      url: http://repairer:8022/v1/repair
     WalletManagement:
       name: WalletManagement
-      url: http://localhost:8022/v1/wallet
+      url: http://fistful:8022/v1/wallet
     WithdrawalManagement:
       name: WithdrawalManagement
-      url: http://localhost:8022/v1/wallet
+      url: http://fistful:8022/v1/withdrawal
+    Automaton:
+      name: Automaton
+      url: http://machinegun-ha:8022/v1/automaton
+    Repairer:
+      name: Repairer
+      url: http://repairer:8022/v1/repair/withdrawal/session
+    FistfulAdmin:
+      name: FistfulAdmin
+      url: http://fistful:8022/v1/admin
+    Deanonimus:
+      name: Deanonimus
+      url: http://deanonimus:8022/deanonimus
+    PaymentProcessing:
+      name: PaymentProcessing
+      url: http://hellgate:8022/v1/processing/invoicing
+    IdentityManagement:
+      name: IdentityManagement
+      url: http://fistful:8022/v1/identity
+    Scrooge:
+      name: Scrooge
+      url: http://scrooge:8022/terminal/balance
+    Dominator:
+      name: Dominator
+      url: http://dominator:8022/v1/dominator
+    DMT:
+      name: DMT
+      url: http://dmt.default:8022/v1/domain/repository
+    DMTAuthor:
+      name: DMTAuthor
+      url: http://dmt.default:8022/v1/domain/author
+    DMTClient:
+      name: DMTClient
+      url: http://dmt.default:8022/v1/domain/repository_client
 
 
 http-client:

--- a/src/test/java/dev/vality/wachter/client/WachterClientOperationsTest.java
+++ b/src/test/java/dev/vality/wachter/client/WachterClientOperationsTest.java
@@ -11,7 +11,6 @@ import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -19,7 +18,6 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestClient;
 
-import static dev.vality.wachter.constants.HeadersConstants.WOODY_TRACE_ID;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;

--- a/src/test/java/dev/vality/wachter/client/WachterClientOperationsTest.java
+++ b/src/test/java/dev/vality/wachter/client/WachterClientOperationsTest.java
@@ -11,6 +11,7 @@ import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -20,6 +21,7 @@ import org.springframework.web.client.RestClient;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static dev.vality.wachter.constants.TraceHeadersConstants.X_WOODY_TRACE_ID;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
@@ -67,12 +69,19 @@ class WachterClientOperationsTest {
 
         final var servletRequest = new MockHttpServletRequest();
         servletRequest.setMethod("POST");
+        servletRequest.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        servletRequest.addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
+        servletRequest.addHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE);
+        servletRequest.addHeader(HttpHeaders.ACCEPT_ENCODING, "gzip");
         final var payload = "payload".getBytes();
         final var expectedResponse = "response".getBytes();
 
         server.expect(requestTo("http://upstream"))
                 .andExpect(method(HttpMethod.POST))
                 .andExpect(content().bytes(payload))
+                .andExpect(header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(header(HttpHeaders.ACCEPT_ENCODING, "gzip"))
                 .andRespond(withSuccess(expectedResponse, MediaType.APPLICATION_OCTET_STREAM));
 
         final var client = new WachterClient(restClient);
@@ -81,6 +90,42 @@ class WachterClientOperationsTest {
 
         assertEquals(HttpStatus.OK, actualResponse.statusCode());
         assertArrayEquals(expectedResponse, actualResponse.body());
+        server.verify();
+        otelSpan.end();
+    }
+
+    @Test
+    void shouldFilterDisallowedHeaders() {
+        final var builder = RestClient.builder();
+        final var server = MockRestServiceServer.bindTo(builder).build();
+        final var restClient = builder.build();
+
+        final var traceData = new TraceData();
+        final var otelSpan = tracer.spanBuilder("test-span").startSpan();
+        traceData.setOtelSpan(otelSpan);
+        TraceContext.setCurrentTraceData(traceData);
+        traceData.getServiceSpan().getSpan().setTraceId("filter-trace-id");
+        traceData.getServiceSpan().getSpan().setId("filter-span-id");
+
+        final var servletRequest = new MockHttpServletRequest();
+        servletRequest.setMethod("POST");
+        servletRequest.addHeader(HttpHeaders.AUTHORIZATION, "Bearer secret");
+        servletRequest.addHeader("Service", "Domain");
+        servletRequest.addHeader("cf-ray", "test");
+        servletRequest.addHeader(X_WOODY_TRACE_ID, "should-not-pass");
+
+        server.expect(requestTo("http://upstream/disallowed"))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(headerDoesNotExist(HttpHeaders.AUTHORIZATION))
+                .andExpect(headerDoesNotExist("Service"))
+                .andExpect(headerDoesNotExist("cf-ray"))
+                .andExpect(headerDoesNotExist(X_WOODY_TRACE_ID))
+                .andRespond(withSuccess("{}", MediaType.APPLICATION_JSON));
+
+        final var client = new WachterClient(restClient);
+
+        client.send(servletRequest, null, "http://upstream/disallowed");
+
         server.verify();
         otelSpan.end();
     }

--- a/src/test/java/dev/vality/wachter/config/AbstractKeycloakOpenIdAsWiremockConfig.java
+++ b/src/test/java/dev/vality/wachter/config/AbstractKeycloakOpenIdAsWiremockConfig.java
@@ -2,35 +2,37 @@ package dev.vality.wachter.config;
 
 import dev.vality.wachter.WachterApplication;
 import dev.vality.wachter.auth.utils.KeycloakOpenIdStub;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.wiremock.spring.EnableWireMock;
 
 import java.security.PrivateKey;
 
 @SuppressWarnings("LineLength")
 @SpringBootTest(
-        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
         classes = {WachterApplication.class},
         properties = {
-                "wiremock.server.baseUrl=http://localhost:${wiremock.server.port}",
-                "spring.security.oauth2.resourceserver.url=http://localhost:${wiremock.server.port}",
-                "spring.security.oauth2.resourceserver.jwt.issuer-uri=http://localhost:${wiremock.server.port}/auth/realms/" +
+                "server.port=8083",
+                "spring.security.oauth2.resourceserver.url=${wiremock.server.baseUrl}",
+                "spring.security.oauth2.resourceserver.jwt.issuer-uri=${wiremock.server.baseUrl}/auth/realms/" +
                         "${spring.security.oauth2.resourceserver.jwt.realm}"})
 @AutoConfigureMockMvc
-@AutoConfigureWireMock(port = 0)
+@EnableWireMock
 @ExtendWith(SpringExtension.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public abstract class AbstractKeycloakOpenIdAsWiremockConfig {
 
     @Autowired
     private KeycloakOpenIdStub keycloakOpenIdStub;
 
-    @BeforeAll
-    public static void setUp(@Autowired KeycloakOpenIdStub keycloakOpenIdStub) throws Exception {
+    @BeforeEach
+    public void setUp(@Autowired KeycloakOpenIdStub keycloakOpenIdStub) throws Exception {
         keycloakOpenIdStub.givenStub();
     }
 

--- a/src/test/java/dev/vality/wachter/config/AbstractKeycloakOpenIdAsWiremockConfig.java
+++ b/src/test/java/dev/vality/wachter/config/AbstractKeycloakOpenIdAsWiremockConfig.java
@@ -36,7 +36,7 @@ public abstract class AbstractKeycloakOpenIdAsWiremockConfig {
 
     protected String generateSimpleJwtWithRoles() {
         return keycloakOpenIdStub.generateJwt("Deanonimus", "unknown", "Domain", "messages:methodName",
-                "DominantCache", "!DominantCache:methodName");
+                "DominantCache", "!DominantCache:methodName", "MerchantStatistics", "PaymentAdjustment");
 
     }
 

--- a/src/test/java/dev/vality/wachter/config/tracing/TraceContextHeadersExtractorTest.java
+++ b/src/test/java/dev/vality/wachter/config/tracing/TraceContextHeadersExtractorTest.java
@@ -1,5 +1,6 @@
 package dev.vality.wachter.config.tracing;
 
+import dev.vality.wachter.tracing.TraceContextHeadersExtractor;
 import dev.vality.woody.api.trace.TraceData;
 import dev.vality.woody.api.trace.context.TraceContext;
 import dev.vality.woody.api.trace.context.metadata.user.UserIdentityEmailExtensionKit;
@@ -20,7 +21,7 @@ import org.junit.jupiter.api.Test;
 import java.time.Instant;
 import java.util.Map;
 
-import static dev.vality.wachter.constants.HeadersConstants.*;
+import static dev.vality.wachter.constants.TraceHeadersConstants.*;
 import static dev.vality.woody.api.trace.ContextUtils.setCustomMetadataValue;
 import static dev.vality.woody.api.trace.ContextUtils.setDeadline;
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/dev/vality/wachter/config/tracing/TraceContextHeadersExtractorTest.java
+++ b/src/test/java/dev/vality/wachter/config/tracing/TraceContextHeadersExtractorTest.java
@@ -1,6 +1,7 @@
 package dev.vality.wachter.config.tracing;
 
 import dev.vality.wachter.tracing.TraceContextHeadersExtractor;
+import dev.vality.woody.api.flow.WFlow;
 import dev.vality.woody.api.trace.TraceData;
 import dev.vality.woody.api.trace.context.TraceContext;
 import dev.vality.woody.api.trace.context.metadata.user.UserIdentityEmailExtensionKit;
@@ -22,8 +23,6 @@ import java.time.Instant;
 import java.util.Map;
 
 import static dev.vality.wachter.constants.TraceHeadersConstants.*;
-import static dev.vality.woody.api.trace.ContextUtils.setCustomMetadataValue;
-import static dev.vality.woody.api.trace.ContextUtils.setDeadline;
 import static org.junit.jupiter.api.Assertions.*;
 
 class TraceContextHeadersExtractorTest {
@@ -159,5 +158,113 @@ class TraceContextHeadersExtractorTest {
         assertFalse(headers.containsKey(WOODY_META_USER_IDENTITY_PREFIX + "username"));
 
         otelSpan.end();
+    }
+
+    @Test
+    void shouldExtractAllUserIdentityMetadata() {
+        final var traceData = new TraceData();
+        final var otelSpan = tracer.spanBuilder("test-span").startSpan();
+        traceData.setOtelSpan(otelSpan);
+        TraceContext.setCurrentTraceData(traceData);
+
+        final var activeSpan = traceData.getActiveSpan();
+        final var span = activeSpan.getSpan();
+        span.setTraceId("GZvsthKQAAA");
+        span.setId("GZvsthKQBBB");
+        span.setParentId("undefined");
+
+        activeSpan.getCustomMetadata().putValue(UserIdentityIdExtensionKit.KEY, "b54a93c4-415d-4f33-a5e9-3608fd043ff4");
+        activeSpan.getCustomMetadata().putValue(UserIdentityUsernameExtensionKit.KEY, "e.cherniak@empayre.com");
+        activeSpan.getCustomMetadata().putValue(UserIdentityEmailExtensionKit.KEY, "e.cherniak@empayre.com");
+        activeSpan.getCustomMetadata().putValue(UserIdentityRealmExtensionKit.KEY, "/internal");
+
+        final Map<String, String> headers = TraceContextHeadersExtractor.extractHeaders();
+
+        assertEquals("b54a93c4-415d-4f33-a5e9-3608fd043ff4", headers.get(WOODY_META_USER_IDENTITY_PREFIX + "id"));
+        assertEquals("e.cherniak@empayre.com", headers.get(WOODY_META_USER_IDENTITY_PREFIX + "username"));
+        assertEquals("e.cherniak@empayre.com", headers.get(WOODY_META_USER_IDENTITY_PREFIX + "email"));
+        assertEquals("/internal", headers.get(WOODY_META_USER_IDENTITY_PREFIX + "realm"));
+
+        otelSpan.end();
+    }
+
+    @Test
+    void shouldGenerateValidTraceparent() {
+        final var traceData = new TraceData();
+        final var otelSpan = tracer.spanBuilder("test-span").startSpan();
+        traceData.setOtelSpan(otelSpan);
+        TraceContext.setCurrentTraceData(traceData);
+
+        final var span = traceData.getActiveSpan().getSpan();
+        span.setTraceId("trace-id");
+        span.setId("span-id");
+
+        final Map<String, String> headers = TraceContextHeadersExtractor.extractHeaders();
+
+        final String traceparent = headers.get(OTEL_TRACE_PARENT);
+        assertNotNull(traceparent);
+        assertTrue(traceparent.matches("00-[0-9a-f]{32}-[0-9a-f]{16}-0[0-1]"));
+
+        otelSpan.end();
+    }
+
+    @Test
+    void shouldExtractComplexScenarioWithAllHeaders() {
+        final var traceData = new TraceData();
+        TraceContext.initNewServiceTrace(traceData, WFlow.createDefaultIdGenerator(), WFlow.createDefaultIdGenerator());
+
+        final var otelSpan = tracer.spanBuilder("test-span").startSpan();
+        traceData.setOtelSpan(otelSpan);
+        TraceContext.setCurrentTraceData(traceData);
+
+        final var activeSpan = traceData.getActiveSpan();
+        final var span = activeSpan.getSpan();
+        span.setTraceId("GZyWNGugAAA");
+        span.setId("GZyWNGugBBB");
+        span.setParentId("undefined");
+        span.setDeadline(Instant.parse("2030-01-01T00:00:00Z"));
+
+        final var metadata = activeSpan.getCustomMetadata();
+        metadata.putValue(UserIdentityIdExtensionKit.KEY, "b54a93c4-415d-4f33-a5e9-3608fd043ff4");
+        metadata.putValue(UserIdentityUsernameExtensionKit.KEY, "e.cherniak@empayre.com");
+        metadata.putValue(UserIdentityEmailExtensionKit.KEY, "e.cherniak@empayre.com");
+        metadata.putValue(UserIdentityRealmExtensionKit.KEY, "/internal");
+        metadata.putValue(X_REQUEST_ID, "req-12345");
+        metadata.putValue(X_REQUEST_DEADLINE, "2030-01-01T00:00:00Z");
+
+        final Map<String, String> headers = TraceContextHeadersExtractor.extractHeaders();
+
+        assertEquals("GZyWNGugAAA", headers.get(WOODY_TRACE_ID));
+        assertEquals("GZyWNGugBBB", headers.get(WOODY_SPAN_ID));
+        assertEquals("undefined", headers.get(WOODY_PARENT_ID));
+        assertEquals("2030-01-01T00:00:00Z", headers.get(WOODY_DEADLINE));
+        assertEquals("b54a93c4-415d-4f33-a5e9-3608fd043ff4", headers.get(WOODY_META_USER_IDENTITY_PREFIX + "id"));
+        assertEquals("e.cherniak@empayre.com", headers.get(WOODY_META_USER_IDENTITY_PREFIX + "username"));
+        assertEquals("e.cherniak@empayre.com", headers.get(WOODY_META_USER_IDENTITY_PREFIX + "email"));
+        assertEquals("/internal", headers.get(WOODY_META_USER_IDENTITY_PREFIX + "realm"));
+        assertEquals("req-12345", headers.get(X_REQUEST_ID));
+        assertEquals("2030-01-01T00:00:00Z", headers.get(X_REQUEST_DEADLINE));
+        assertNotNull(headers.get(OTEL_TRACE_PARENT));
+
+        otelSpan.end();
+    }
+
+    @Test
+    void shouldThrowWhenTraceDataIsNull() {
+        TraceContext.setCurrentTraceData(null);
+
+        assertThrows(NullPointerException.class, () -> {
+            TraceContextHeadersExtractor.extractHeaders();
+        });
+    }
+
+    @Test
+    void shouldThrowWhenOtelSpanIsNull() {
+        final var traceData = new TraceData();
+        TraceContext.setCurrentTraceData(traceData);
+
+        assertThrows(NullPointerException.class, () -> {
+            TraceContextHeadersExtractor.extractHeaders();
+        });
     }
 }

--- a/src/test/java/dev/vality/wachter/config/tracing/WoodyTracingFilterTest.java
+++ b/src/test/java/dev/vality/wachter/config/tracing/WoodyTracingFilterTest.java
@@ -1,6 +1,6 @@
 package dev.vality.wachter.config.tracing;
 
-import dev.vality.woody.api.trace.TraceData;
+import dev.vality.wachter.tracing.WoodyTracingFilter;
 import dev.vality.woody.api.trace.context.TraceContext;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
@@ -15,7 +15,7 @@ import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
-import static dev.vality.wachter.constants.HeadersConstants.*;
+import static dev.vality.wachter.constants.TraceHeadersConstants.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 class WoodyTracingFilterTest {

--- a/src/test/java/dev/vality/wachter/controller/ErrorControllerTest.java
+++ b/src/test/java/dev/vality/wachter/controller/ErrorControllerTest.java
@@ -64,7 +64,7 @@ class ErrorControllerTest extends AbstractKeycloakOpenIdAsWiremockConfig {
         final var expected = "User darkside-the-best@mail.com don't have roles";
         mvc.perform(post("/wachter")
                         .header("Authorization", "Bearer " + generateSimpleJwtWithoutRoles())
-                        .header("Service", "messages")
+                        .header("Service", "Domain")
                         .header("X-Request-ID", randomUUID())
                         .header("X-Request-Deadline", Instant.now().plus(1, ChronoUnit.DAYS).toString())
                         .content(TMessageUtil.createTMessage(protocolFactory)))

--- a/src/test/java/dev/vality/wachter/controller/WachterControllerDisabledAuthTest.java
+++ b/src/test/java/dev/vality/wachter/controller/WachterControllerDisabledAuthTest.java
@@ -63,7 +63,7 @@ class WachterControllerDisabledAuthTest extends AbstractKeycloakOpenIdAsWiremock
                 .thenReturn(new WachterClientResponse(HttpStatus.OK, new HttpHeaders(), new byte[0]));
         mvc.perform(post("/wachter")
                         .header("Authorization", "Bearer " + generateSimpleJwtWithoutRoles())
-                        .header("Service", "messages")
+                        .header("Service", "Domain")
                         .header("X-Request-ID", randomUUID())
                         .header("X-Request-Deadline", Instant.now().plus(1, ChronoUnit.DAYS).toString())
                         .content(TMessageUtil.createTMessage(protocolFactory)))

--- a/src/test/java/dev/vality/wachter/controller/WachterControllerTest.java
+++ b/src/test/java/dev/vality/wachter/controller/WachterControllerTest.java
@@ -77,7 +77,7 @@ class WachterControllerTest extends AbstractKeycloakOpenIdAsWiremockConfig {
                 .thenReturn(new WachterClientResponse(HttpStatus.OK, new HttpHeaders(), new byte[0]));
         mvc.perform(post("/wachter")
                         .header("Authorization", "Bearer " + generateSimpleJwtWithRoles())
-                        .header("Service", "messages")
+                        .header("Service", "Domain")
                         .header("X-Request-ID", randomUUID())
                         .header("X-Request-Deadline", Instant.now().plus(1, ChronoUnit.DAYS).toString())
                         .content(TMessageUtil.createTMessage(protocolFactory)))

--- a/src/test/java/dev/vality/wachter/controller/WachterControllerTest.java
+++ b/src/test/java/dev/vality/wachter/controller/WachterControllerTest.java
@@ -19,6 +19,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 
+import static dev.vality.wachter.constants.TraceHeadersConstants.*;
 import static java.util.UUID.randomUUID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -62,8 +63,8 @@ class WachterControllerTest extends AbstractKeycloakOpenIdAsWiremockConfig {
         mvc.perform(post("/wachter")
                         .header("Authorization", "Bearer " + generateSimpleJwtWithRoles())
                         .header("Service", "Domain")
-                        .header("X-Request-ID", randomUUID())
-                        .header("X-Request-Deadline", Instant.now().plus(1, ChronoUnit.DAYS).toString())
+                        .header(X_REQUEST_ID, randomUUID())
+                        .header(X_REQUEST_DEADLINE, Instant.now().plus(1, ChronoUnit.DAYS).toString())
                         .content(TMessageUtil.createTMessage(protocolFactory)))
                 .andDo(print())
                 .andExpect(status().is2xxSuccessful());
@@ -78,8 +79,8 @@ class WachterControllerTest extends AbstractKeycloakOpenIdAsWiremockConfig {
         mvc.perform(post("/wachter")
                         .header("Authorization", "Bearer " + generateSimpleJwtWithRoles())
                         .header("Service", "Domain")
-                        .header("X-Request-ID", randomUUID())
-                        .header("X-Request-Deadline", Instant.now().plus(1, ChronoUnit.DAYS).toString())
+                        .header(X_REQUEST_ID, randomUUID())
+                        .header(X_REQUEST_DEADLINE, Instant.now().plus(1, ChronoUnit.DAYS).toString())
                         .content(TMessageUtil.createTMessage(protocolFactory)))
                 .andDo(print())
                 .andExpect(status().is2xxSuccessful());
@@ -94,12 +95,12 @@ class WachterControllerTest extends AbstractKeycloakOpenIdAsWiremockConfig {
         mvc.perform(post("/wachter")
                         .header("Authorization", "Bearer " + generateSimpleJwtWithRoles())
                         .header("Service", "Domain")
-                        .header("X-Request-ID", randomUUID())
-                        .header("X-Request-Deadline", Instant.now().plus(1, ChronoUnit.DAYS).toString())
-                        .header("woody.parent-id", "parent")
-                        .header("woody.trace-id", "trace")
-                        .header("woody.span-id", "span")
-                        .header("woody.deadline", "deadline")
+                        .header(X_REQUEST_ID, randomUUID())
+                        .header(X_REQUEST_DEADLINE, Instant.now().plus(1, ChronoUnit.DAYS).toString())
+                        .header(WOODY_PARENT_ID, "parent")
+                        .header(WOODY_TRACE_ID, "trace")
+                        .header(WOODY_SPAN_ID, "span")
+                        .header(WOODY_DEADLINE, "deadline")
                         .content(TMessageUtil.createTMessage(protocolFactory)))
                 .andDo(print())
                 .andExpect(status().is2xxSuccessful());
@@ -114,12 +115,12 @@ class WachterControllerTest extends AbstractKeycloakOpenIdAsWiremockConfig {
         mvc.perform(post("/wachter")
                         .header("Authorization", "Bearer " + generateSimpleJwtWithRoles())
                         .header("Service", "Domain")
-                        .header("X-Request-ID", randomUUID())
-                        .header("X-Request-Deadline", Instant.now().plus(1, ChronoUnit.DAYS).toString())
-                        .header("x-woody-parent-id", "parent")
-                        .header("x-woody-trace-id", "trace")
-                        .header("x-woody-span-id", "span")
-                        .header("x-woody-deadline", "deadline")
+                        .header(X_REQUEST_ID, randomUUID())
+                        .header(X_REQUEST_DEADLINE, Instant.now().plus(1, ChronoUnit.DAYS).toString())
+                        .header(X_WOODY_PARENT_ID, "parent")
+                        .header(X_WOODY_TRACE_ID, "trace")
+                        .header(X_WOODY_SPAN_ID, "span")
+                        .header(X_WOODY_DEADLINE, "deadline")
                         .content(TMessageUtil.createTMessage(protocolFactory)))
                 .andDo(print())
                 .andExpect(status().is2xxSuccessful());
@@ -138,8 +139,8 @@ class WachterControllerTest extends AbstractKeycloakOpenIdAsWiremockConfig {
         mvc.perform(post("/wachter")
                         .header("Authorization", "Bearer " + generateSimpleJwtWithRoles())
                         .header("Service", "Domain")
-                        .header("X-Request-ID", randomUUID())
-                        .header("X-Request-Deadline", Instant.now().plus(1, ChronoUnit.DAYS).toString())
+                        .header(X_REQUEST_ID, randomUUID())
+                        .header(X_REQUEST_DEADLINE, Instant.now().plus(1, ChronoUnit.DAYS).toString())
                         .content(TMessageUtil.createTMessage(protocolFactory)))
                 .andDo(print())
                 .andExpect(status().isBadGateway())

--- a/src/test/java/dev/vality/wachter/integration/WachterIntegrationTest.java
+++ b/src/test/java/dev/vality/wachter/integration/WachterIntegrationTest.java
@@ -108,10 +108,10 @@ class WachterIntegrationTest extends AbstractKeycloakOpenIdAsWiremockConfig {
                     headers.set("cf-visitor", "{\"scheme\":\"https\"}");
                     headers.set("cf-warp-tag-id", "ef03c554-2080-404d-bd10-1928b8a59810");
                     headers.set("dnt", "1");
-                    headers.set("origin", "https://iddqd.empayre.com");
+                    headers.set("origin", "https://iddqd.valitydev.com");
                     headers.set("pragma", "no-cache");
                     headers.set("priority", "u=4");
-                    headers.set("referer", "https://iddqd.empayre.com/");
+                    headers.set("referer", "https://iddqd.valitydev.com/");
                     headers.set("sec-fetch-dest", "empty");
                     headers.set("sec-fetch-mode", "cors");
                     headers.set("sec-fetch-site", "same-site");
@@ -127,8 +127,8 @@ class WachterIntegrationTest extends AbstractKeycloakOpenIdAsWiremockConfig {
                     headers.set(X_WOODY_SPAN_ID, spanId);
                     headers.set(X_WOODY_PARENT_ID, parentId);
                     headers.set(X_WOODY_META_USER_IDENTITY_PREFIX + "id", "b54a93c4-415d-4f33-a5e9-3608fd043ff4");
-                    headers.set(X_WOODY_META_USER_IDENTITY_PREFIX + "username", "noreply@empayre.com");
-                    headers.set(X_WOODY_META_USER_IDENTITY_PREFIX + "email", "noreply@empayre.com");
+                    headers.set(X_WOODY_META_USER_IDENTITY_PREFIX + "username", "noreply@valitydev.com");
+                    headers.set(X_WOODY_META_USER_IDENTITY_PREFIX + "email", "noreply@valitydev.com");
                     headers.set(X_WOODY_META_USER_IDENTITY_PREFIX + "realm", "internal");
 
                     // Request metadata

--- a/src/test/java/dev/vality/wachter/integration/WachterIntegrationTest.java
+++ b/src/test/java/dev/vality/wachter/integration/WachterIntegrationTest.java
@@ -1,54 +1,61 @@
 package dev.vality.wachter.integration;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import dev.vality.wachter.config.AbstractKeycloakOpenIdAsWiremockConfig;
-import dev.vality.wachter.constants.TraceHeadersConstants;
 import dev.vality.wachter.testutil.TMessageUtil;
 import dev.vality.woody.api.trace.context.TraceContext;
-import dev.vality.woody.api.trace.context.metadata.user.UserIdentityEmailExtensionKit;
-import dev.vality.woody.api.trace.context.metadata.user.UserIdentityIdExtensionKit;
-import dev.vality.woody.api.trace.context.metadata.user.UserIdentityRealmExtensionKit;
-import dev.vality.woody.api.trace.context.metadata.user.UserIdentityUsernameExtensionKit;
 import org.apache.thrift.protocol.TProtocolFactory;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.web.client.RestClient;
 
+import java.net.http.HttpClient;
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static dev.vality.wachter.constants.TraceHeadersConstants.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.junit.jupiter.api.Assertions.*;
 
 @TestPropertySource(properties = {
-        "wachter.services.Domain.url=http://localhost:${wiremock.server.port}/domain"
+        "wachter.services.Domain.url=http://localhost:${wiremock.server.port}/domain",
+        "wachter.services.Deanonimus.url=http://localhost:${wiremock.server.port}/deanonimus",
+        "wachter.services.MerchantStatistics.url=http://localhost:${wiremock.server.port}/magista"
 })
 class WachterIntegrationTest extends AbstractKeycloakOpenIdAsWiremockConfig {
 
-    private static final String USER_ID_HEADER = WOODY_META_USER_IDENTITY_PREFIX +
-            TraceHeadersConstants.WoodySuffixes.userIdentitySuffix(UserIdentityIdExtensionKit.KEY);
-    private static final String USER_NAME_HEADER = WOODY_META_USER_IDENTITY_PREFIX +
-            TraceHeadersConstants.WoodySuffixes.userIdentitySuffix(UserIdentityUsernameExtensionKit.KEY);
-    private static final String USER_EMAIL_HEADER = WOODY_META_USER_IDENTITY_PREFIX +
-            TraceHeadersConstants.WoodySuffixes.userIdentitySuffix(UserIdentityEmailExtensionKit.KEY);
-    private static final String USER_REALM_HEADER = WOODY_META_USER_IDENTITY_PREFIX +
-            TraceHeadersConstants.WoodySuffixes.userIdentitySuffix(UserIdentityRealmExtensionKit.KEY);
     private static final String TRACEPARENT_PATTERN = "00-[0-9a-f]{32}-[0-9a-f]{16}-0[0-1]";
-    private static final String EXPECTED_REALM = "/internal";
 
-    @Autowired
-    private MockMvc mockMvc;
+    @LocalServerPort
+    private int port;
+
+    private RestClient restClient;
 
     @Autowired
     private TProtocolFactory protocolFactory;
+
+    @BeforeEach
+    void setUpRestClient() {
+        restClient = RestClient.builder()
+                .baseUrl("http://localhost:" + port)
+                .defaultStatusHandler(status -> true, (request, response) -> {
+                })
+                .requestFactory(new JdkClientHttpRequestFactory(HttpClient.newBuilder()
+                        .followRedirects(HttpClient.Redirect.NEVER)
+                        .build()))
+                .build();
+    }
 
     @AfterEach
     void tearDown() {
@@ -57,39 +64,184 @@ class WachterIntegrationTest extends AbstractKeycloakOpenIdAsWiremockConfig {
     }
 
     @Test
-    void shouldProxyRequestEndToEnd() throws Exception {
-        final var traceId = "integration-trace";
-        final var spanId = "integration-span";
-        final var parentId = "integration-parent";
+    void shouldProxyRequestWithCompleteTracingHeaders() throws Exception {
+        final var traceId = "GZyWNGugAAA";
+        final var spanId = "GZyWNGugBBB";
+        final var parentId = "undefined";
         final var deadline = Instant.now().plusSeconds(300);
         final var requestId = UUID.randomUUID().toString();
         final var payload = TMessageUtil.createTMessage(protocolFactory);
         final var responseBody = "integration-response".getBytes();
         final var upstreamTraceparent = "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01";
 
-        stubFor(WireMock.post(urlEqualTo("/domain"))
+        stubFor(post(urlEqualTo("/deanonimus"))
                 .withRequestBody(binaryEqualTo(payload))
                 .willReturn(aResponse()
-                        .withStatus(HttpStatus.ACCEPTED.value())
-                        .withHeader("X-Upstream", "accepted")
+                        .withStatus(HttpStatus.OK.value())
                         .withHeader("traceparent", upstreamTraceparent)
-                        .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_OCTET_STREAM_VALUE)
+                        .withHeader(HttpHeaders.CONTENT_TYPE, "application/x-thrift")
                         .withBody(responseBody)));
 
-        mockMvc.perform(post("/wachter")
-                        .header("Authorization", "Bearer " + generateSimpleJwtWithRoles())
-                        .header("Service", "Domain")
-                        .header(X_REQUEST_ID, requestId)
-                        .header(X_REQUEST_DEADLINE, deadline.toString())
-                        .header(X_WOODY_TRACE_ID, traceId)
-                        .header(X_WOODY_SPAN_ID, spanId)
-                        .header(X_WOODY_PARENT_ID, parentId)
-                        .content(payload))
-                .andExpect(status().isAccepted())
-                .andExpect(MockMvcResultMatchers.content().bytes(responseBody));
+        final ResponseEntity<byte[]> response = restClient.post()
+                .uri("/wachter")
+                .contentType(MediaType.valueOf("application/x-thrift"))
+                .headers(headers -> {
+                    // Browser/CDN headers - should be filtered out
+                    headers.set("user-agent",
+                            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:143.0) Gecko/20100101 Firefox/143.0");
+                    headers.set("accept", "application/x-thrift");
+                    headers.set("accept-encoding", "gzip, br");
+                    headers.set("accept-language", "ru-RU,ru;q=0.8,en-US;q=0.5,en;q=0.3");
+                    headers.set("cache-control", "no-cache");
+                    headers.set("cdn-loop", "cloudflare; loops=1");
+                    headers.set("cf-connecting-ip", "185.121.234.44");
+                    headers.set("cf-ipcountry", "NL");
+                    headers.set("cf-ray", "98be96799e2ae4bc-AMS");
+                    headers.set("cf-visitor", "{\"scheme\":\"https\"}");
+                    headers.set("cf-warp-tag-id", "ef03c554-2080-404d-bd10-1928b8a59810");
+                    headers.set("dnt", "1");
+                    headers.set("origin", "https://iddqd.empayre.com");
+                    headers.set("pragma", "no-cache");
+                    headers.set("priority", "u=4");
+                    headers.set("referer", "https://iddqd.empayre.com/");
+                    headers.set("sec-fetch-dest", "empty");
+                    headers.set("sec-fetch-mode", "cors");
+                    headers.set("sec-fetch-site", "same-site");
+                    headers.set("sec-gpc", "1");
+                    headers.set("x-forwarded-proto", "https");
 
-        verify(postRequestedFor(urlEqualTo("/domain"))
-                .withRequestBody(binaryEqualTo(payload)));
+                    // Authentication and service
+                    headers.set("Authorization", "Bearer " + generateSimpleJwtWithRoles());
+                    headers.set("Service", "Deanonimus");
+
+                    // Woody tracing headers
+                    headers.set("x-woody-trace-id", traceId);
+                    headers.set("x-woody-span-id", spanId);
+                    headers.set("x-woody-parent-id", parentId);
+                    headers.set("x-woody-meta-user-identity-id", "b54a93c4-415d-4f33-a5e9-3608fd043ff4");
+                    headers.set("x-woody-meta-user-identity-username", "e.cherniak@empayre.com");
+                    headers.set("x-woody-meta-user-identity-email", "e.cherniak@empayre.com");
+                    headers.set("x-woody-meta-user-identity-realm", "internal");
+
+                    // Request metadata
+                    headers.set(X_REQUEST_ID, requestId);
+                    headers.set(X_REQUEST_DEADLINE, deadline.toString());
+                })
+                .body(payload)
+                .retrieve()
+                .toEntity(byte[].class);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(upstreamTraceparent, response.getHeaders().getFirst("traceparent"));
+        assertArrayEquals(responseBody, response.getBody());
+
+        // Verify upstream request headers
+        List<LoggedRequest> requests = findAll(postRequestedFor(urlEqualTo("/deanonimus")));
+        assertEquals(1, requests.size());
+        LoggedRequest upstreamRequest = requests.get(0);
+
+        // Verify woody tracing headers were sent
+        assertEquals(traceId, upstreamRequest.getHeader(WOODY_TRACE_ID));
+        assertEquals(spanId, upstreamRequest.getHeader(WOODY_SPAN_ID));
+        assertEquals(parentId, upstreamRequest.getHeader(WOODY_PARENT_ID));
+        assertTrue(upstreamRequest.containsHeader(WOODY_DEADLINE));
+
+        // Verify user identity metadata was sent (from headers, not JWT because headers take precedence)
+        assertEquals("b54a93c4-415d-4f33-a5e9-3608fd043ff4",
+                upstreamRequest.getHeader(WOODY_META_USER_IDENTITY_PREFIX + "id"));
+        assertEquals("e.cherniak@empayre.com", upstreamRequest.getHeader(WOODY_META_USER_IDENTITY_PREFIX + "username"));
+        assertEquals("e.cherniak@empayre.com", upstreamRequest.getHeader(WOODY_META_USER_IDENTITY_PREFIX + "email"));
+        assertEquals("internal", upstreamRequest.getHeader(WOODY_META_USER_IDENTITY_PREFIX + "realm"));
+
+        // Verify OpenTelemetry traceparent was sent
+        assertNotNull(upstreamRequest.getHeader(OTEL_TRACE_PARENT));
+        assertTrue(upstreamRequest.getHeader(OTEL_TRACE_PARENT).matches(TRACEPARENT_PATTERN));
+
+        // Verify request metadata was sent
+        assertEquals(requestId, upstreamRequest.getHeader(X_REQUEST_ID));
+        assertEquals(deadline.toString(), upstreamRequest.getHeader(X_REQUEST_DEADLINE));
+
+        // Verify browser/CDN headers were NOT sent
+        assertFalse(upstreamRequest.containsHeader("cf-ray"));
+        assertFalse(upstreamRequest.containsHeader("cdn-loop"));
+        assertFalse(upstreamRequest.containsHeader("cf-visitor"));
+        assertFalse(upstreamRequest.containsHeader("dnt"));
+        assertFalse(upstreamRequest.containsHeader("sec-fetch-mode"));
+        assertFalse(upstreamRequest.containsHeader("pragma"));
+        assertFalse(upstreamRequest.containsHeader("cache-control"));
+        assertFalse(upstreamRequest.containsHeader("origin"));
+        assertFalse(upstreamRequest.containsHeader("referer"));
+    }
+
+    @Test
+    void shouldNormalizeAndForwardMixedWoodyHeaders() throws Exception {
+        final var deadline = Instant.now().plusSeconds(300);
+        final var payload = TMessageUtil.createTMessage(protocolFactory);
+        final var responseBody = "test-response".getBytes();
+
+        stubFor(post(urlEqualTo("/magista"))
+                .withRequestBody(binaryEqualTo(payload))
+                .willReturn(aResponse()
+                        .withStatus(HttpStatus.OK.value())
+                        .withHeader(HttpHeaders.CONTENT_TYPE, "application/x-thrift")
+                        .withBody(responseBody)));
+
+        final ResponseEntity<byte[]> response = restClient.post()
+                .uri("/wachter")
+                .contentType(MediaType.valueOf("application/x-thrift"))
+                .headers(headers -> {
+                    headers.set("Authorization", "Bearer " + generateSimpleJwtWithRoles());
+                    headers.set("Service", "Domain");
+
+                    // Mixed woody and x-woody headers
+                    headers.set("woody.trace-id", "GZvsthKQAAA");
+                    headers.set("x-woody-span-id", "GZvsthKQBBB");
+                    headers.set("woody.parent-id", "parent-woody");
+                    headers.set("x-woody-deadline", deadline.toString());
+
+                    // User identity in different formats
+                    headers.set("woody.meta.user-identity.realm", "/woody-realm");
+                    headers.set("x-woody-meta-user-identity-id", "header-user-id");
+
+                    // Request metadata
+                    headers.set(X_REQUEST_ID, "mixed-request-id");
+                    headers.set(X_REQUEST_DEADLINE, deadline.toString());
+
+                    // Traceparent
+                    headers.set("traceparent", "00-abc123def456789012345678901234-fedcba9876543210-01");
+                })
+                .body(payload)
+                .retrieve()
+                .toEntity(byte[].class);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertArrayEquals(responseBody, response.getBody());
+
+        // Verify upstream request headers were normalized correctly
+        List<LoggedRequest> requests = findAll(postRequestedFor(urlEqualTo("/magista")));
+        assertEquals(1, requests.size());
+        LoggedRequest upstreamRequest = requests.get(0);
+
+        // All headers should be normalized to woody.* format
+        assertEquals("GZvsthKQAAA", upstreamRequest.getHeader(WOODY_TRACE_ID));
+        assertEquals("GZvsthKQBBB", upstreamRequest.getHeader(WOODY_SPAN_ID));
+        assertEquals("parent-woody", upstreamRequest.getHeader(WOODY_PARENT_ID));
+        assertNotNull(upstreamRequest.getHeader(WOODY_DEADLINE));
+
+        // User identity should combine headers and JWT data (header-user-id from header, others from JWT)
+        assertEquals("header-user-id", upstreamRequest.getHeader(WOODY_META_USER_IDENTITY_PREFIX + "id"));
+        assertEquals("Darth Vader", upstreamRequest.getHeader(WOODY_META_USER_IDENTITY_PREFIX + "username"));
+        assertEquals("darkside-the-best@mail.com",
+                upstreamRequest.getHeader(WOODY_META_USER_IDENTITY_PREFIX + "email"));
+        assertEquals("/woody-realm", upstreamRequest.getHeader(WOODY_META_USER_IDENTITY_PREFIX + "realm"));
+
+        // Traceparent should be preserved
+        assertEquals("00-abc123def456789012345678901234-fedcba9876543210-01",
+                upstreamRequest.getHeader(OTEL_TRACE_PARENT));
+
+        // Request metadata should be preserved
+        assertEquals("mixed-request-id", upstreamRequest.getHeader(X_REQUEST_ID));
+        assertEquals(deadline.toString(), upstreamRequest.getHeader(X_REQUEST_DEADLINE));
     }
 
     @Test
@@ -102,19 +254,29 @@ class WachterIntegrationTest extends AbstractKeycloakOpenIdAsWiremockConfig {
                 .willReturn(aResponse()
                         .withStatus(HttpStatus.OK.value())));
 
-        mockMvc.perform(post("/wachter")
-                        .header("Authorization", "Bearer " + generateSimpleJwtWithRoles())
-                        .header("Service", "Domain")
-                        .header(X_REQUEST_ID, UUID.randomUUID().toString())
-                        .header(X_REQUEST_DEADLINE, deadline.toString())
-                        .header(HttpHeaders.TRANSFER_ENCODING, "chunked")
-                        .header(HttpHeaders.CONNECTION, "keep-alive")
-                        .header(HttpHeaders.TE, "trailers")
-                        .header(HttpHeaders.HOST, "example.org")
-                        .content(payload))
-                .andExpect(status().isOk());
+        final ResponseEntity<byte[]> response = restClient.post()
+                .uri("/wachter")
+                .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                .headers(headers -> {
+                    headers.set("Authorization", "Bearer " + generateSimpleJwtWithRoles());
+                    headers.set("Service", "Domain");
+                    headers.set(X_REQUEST_ID, UUID.randomUUID().toString());
+                    headers.set(X_REQUEST_DEADLINE, deadline.toString());
+                    headers.set(HttpHeaders.TRANSFER_ENCODING, "chunked");
+                    headers.set(HttpHeaders.CONNECTION, "keep-alive");
+                    headers.set(HttpHeaders.TE, "trailers");
+                    headers.set(HttpHeaders.HOST, "example.org");
+                })
+                .body(payload)
+                .retrieve()
+                .toEntity(byte[].class);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
 
         verify(postRequestedFor(urlEqualTo("/domain"))
+                .withHeader(HttpHeaders.HOST, matching("localhost:\\d+"))
+                .withoutHeader(HttpHeaders.TRANSFER_ENCODING)
+                .withoutHeader(HttpHeaders.TE)
                 .withRequestBody(binaryEqualTo(payload)));
     }
 
@@ -129,16 +291,23 @@ class WachterIntegrationTest extends AbstractKeycloakOpenIdAsWiremockConfig {
                 .willReturn(aResponse()
                         .withStatus(HttpStatus.OK.value())));
 
-        mockMvc.perform(post("/wachter")
-                        .header("Authorization", "Bearer " + generateSimpleJwtWithRoles())
-                        .header("Service", "Domain")
-                        .header(X_REQUEST_ID, UUID.randomUUID().toString())
-                        .header(X_REQUEST_DEADLINE, deadline.toString())
-                        .header(HttpHeaders.ORIGIN, origin)
-                        .content(payload))
-                .andExpect(status().isOk())
-                .andExpect(MockMvcResultMatchers.header()
-                        .exists(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN));
+        final ResponseEntity<byte[]> response = restClient.post()
+                .uri("/wachter")
+                .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                .headers(headers -> {
+                    headers.set("Authorization", "Bearer " + generateSimpleJwtWithRoles());
+                    headers.set("Service", "Domain");
+                    headers.set(X_REQUEST_ID, UUID.randomUUID().toString());
+                    headers.set(X_REQUEST_DEADLINE, deadline.toString());
+                    headers.set(HttpHeaders.ORIGIN, origin);
+                })
+                .body(payload)
+                .retrieve()
+                .toEntity(byte[].class);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("*", response.getHeaders().getFirst(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN));
+        assertNull(response.getHeaders().getFirst(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS));
     }
 
     @Test
@@ -152,15 +321,22 @@ class WachterIntegrationTest extends AbstractKeycloakOpenIdAsWiremockConfig {
                 .willReturn(aResponse()
                         .withStatus(HttpStatus.BAD_GATEWAY.value())));
 
-        mockMvc.perform(post("/wachter")
-                        .header("Authorization", "Bearer " + generateSimpleJwtWithRoles())
-                        .header("Service", "Domain")
-                        .header(X_REQUEST_ID, UUID.randomUUID().toString())
-                        .header(X_REQUEST_DEADLINE, deadline.toString())
-                        .header(HttpHeaders.ORIGIN, origin)
-                        .content(payload))
-                .andExpect(status().isBadGateway())
-                .andExpect(MockMvcResultMatchers.header()
-                        .exists(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN));
+        final ResponseEntity<byte[]> response = restClient.post()
+                .uri("/wachter")
+                .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                .headers(headers -> {
+                    headers.set("Authorization", "Bearer " + generateSimpleJwtWithRoles());
+                    headers.set("Service", "Domain");
+                    headers.set(X_REQUEST_ID, UUID.randomUUID().toString());
+                    headers.set(X_REQUEST_DEADLINE, deadline.toString());
+                    headers.set(HttpHeaders.ORIGIN, origin);
+                })
+                .body(payload)
+                .retrieve()
+                .toEntity(byte[].class);
+
+        assertEquals(HttpStatus.BAD_GATEWAY, response.getStatusCode());
+        assertEquals("*", response.getHeaders().getFirst(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN));
+        assertNull(response.getHeaders().getFirst(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS));
     }
 }

--- a/src/test/java/dev/vality/wachter/integration/WachterIntegrationTest.java
+++ b/src/test/java/dev/vality/wachter/integration/WachterIntegrationTest.java
@@ -1,9 +1,8 @@
 package dev.vality.wachter.integration;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
-import dev.vality.wachter.auth.utils.JwtTokenBuilder;
 import dev.vality.wachter.config.AbstractKeycloakOpenIdAsWiremockConfig;
-import dev.vality.wachter.constants.HeadersConstants;
+import dev.vality.wachter.constants.TraceHeadersConstants;
 import dev.vality.wachter.testutil.TMessageUtil;
 import dev.vality.woody.api.trace.context.TraceContext;
 import dev.vality.woody.api.trace.context.metadata.user.UserIdentityEmailExtensionKit;
@@ -25,8 +24,7 @@ import java.time.Instant;
 import java.util.UUID;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static dev.vality.wachter.constants.HeadersConstants.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static dev.vality.wachter.constants.TraceHeadersConstants.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -36,13 +34,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class WachterIntegrationTest extends AbstractKeycloakOpenIdAsWiremockConfig {
 
     private static final String USER_ID_HEADER = WOODY_META_USER_IDENTITY_PREFIX +
-            HeadersConstants.WoodySuffixes.userIdentitySuffix(UserIdentityIdExtensionKit.KEY);
+            TraceHeadersConstants.WoodySuffixes.userIdentitySuffix(UserIdentityIdExtensionKit.KEY);
     private static final String USER_NAME_HEADER = WOODY_META_USER_IDENTITY_PREFIX +
-            HeadersConstants.WoodySuffixes.userIdentitySuffix(UserIdentityUsernameExtensionKit.KEY);
+            TraceHeadersConstants.WoodySuffixes.userIdentitySuffix(UserIdentityUsernameExtensionKit.KEY);
     private static final String USER_EMAIL_HEADER = WOODY_META_USER_IDENTITY_PREFIX +
-            HeadersConstants.WoodySuffixes.userIdentitySuffix(UserIdentityEmailExtensionKit.KEY);
+            TraceHeadersConstants.WoodySuffixes.userIdentitySuffix(UserIdentityEmailExtensionKit.KEY);
     private static final String USER_REALM_HEADER = WOODY_META_USER_IDENTITY_PREFIX +
-            HeadersConstants.WoodySuffixes.userIdentitySuffix(UserIdentityRealmExtensionKit.KEY);
+            TraceHeadersConstants.WoodySuffixes.userIdentitySuffix(UserIdentityRealmExtensionKit.KEY);
     private static final String TRACEPARENT_PATTERN = "00-[0-9a-f]{32}-[0-9a-f]{16}-0[0-1]";
     private static final String EXPECTED_REALM = "/internal";
 

--- a/src/test/java/dev/vality/wachter/integration/WachterIntegrationTest.java
+++ b/src/test/java/dev/vality/wachter/integration/WachterIntegrationTest.java
@@ -83,10 +83,10 @@ class WachterIntegrationTest extends AbstractKeycloakOpenIdAsWiremockConfig {
                 .withRequestBody(binaryEqualTo(payload))
                 .willReturn(aResponse()
                         .withStatus(HttpStatus.OK.value())
-                        .withHeader("woody.trace-id", traceId)
-                        .withHeader("woody.parent-id", parentId)
-                        .withHeader("woody.span-id", spanId)
-                        .withHeader("traceparent", upstreamTraceparent)
+                        .withHeader(WOODY_TRACE_ID, traceId)
+                        .withHeader(WOODY_PARENT_ID, parentId)
+                        .withHeader(WOODY_SPAN_ID, spanId)
+                        .withHeader(OTEL_TRACE_PARENT, upstreamTraceparent)
                         .withHeader(HttpHeaders.CONTENT_TYPE, "application/x-thrift")
                         .withBody(responseBody)));
 
@@ -123,25 +123,25 @@ class WachterIntegrationTest extends AbstractKeycloakOpenIdAsWiremockConfig {
                     headers.set("Service", "Deanonimus");
 
                     // Woody tracing headers
-                    headers.set("x-woody-trace-id", traceId);
-                    headers.set("x-woody-span-id", spanId);
-                    headers.set("x-woody-parent-id", parentId);
-                    headers.set("x-woody-meta-user-identity-id", "b54a93c4-415d-4f33-a5e9-3608fd043ff4");
-                    headers.set("x-woody-meta-user-identity-username", "noreply@empayre.com");
-                    headers.set("x-woody-meta-user-identity-email", "noreply@empayre.com");
-                    headers.set("x-woody-meta-user-identity-realm", "internal");
+                    headers.set(X_WOODY_TRACE_ID, traceId);
+                    headers.set(X_WOODY_SPAN_ID, spanId);
+                    headers.set(X_WOODY_PARENT_ID, parentId);
+                    headers.set(X_WOODY_META_USER_IDENTITY_PREFIX + "id", "b54a93c4-415d-4f33-a5e9-3608fd043ff4");
+                    headers.set(X_WOODY_META_USER_IDENTITY_PREFIX + "username", "noreply@empayre.com");
+                    headers.set(X_WOODY_META_USER_IDENTITY_PREFIX + "email", "noreply@empayre.com");
+                    headers.set(X_WOODY_META_USER_IDENTITY_PREFIX + "realm", "internal");
 
                     // Request metadata
                     headers.set(X_REQUEST_ID, requestId);
                     headers.set(X_REQUEST_DEADLINE, deadline.toString());
-                    headers.set("traceparent", upstreamTraceparent);
+                    headers.set(OTEL_TRACE_PARENT, upstreamTraceparent);
                 })
                 .body(payload)
                 .retrieve()
                 .toEntity(byte[].class);
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
-        assertEquals(upstreamTraceparent, response.getHeaders().getFirst("traceparent"));
+        assertEquals(upstreamTraceparent, response.getHeaders().getFirst(OTEL_TRACE_PARENT));
         assertArrayEquals(responseBody, response.getBody());
 
         List<LoggedRequest> requests = findAll(postRequestedFor(urlEqualTo("/deanonimus")));
@@ -152,6 +152,14 @@ class WachterIntegrationTest extends AbstractKeycloakOpenIdAsWiremockConfig {
         assertEquals(spanId, upstreamRequest.getHeader(WOODY_SPAN_ID));
         assertEquals(parentId, upstreamRequest.getHeader(WOODY_PARENT_ID));
         assertTrue(upstreamRequest.containsHeader(WOODY_DEADLINE));
+
+        assertEquals("application/x-thrift", upstreamRequest.getHeader(HttpHeaders.CONTENT_TYPE));
+        assertEquals("application/x-thrift", upstreamRequest.getHeader(HttpHeaders.ACCEPT));
+        assertEquals("gzip, br", upstreamRequest.getHeader(HttpHeaders.ACCEPT_ENCODING));
+        assertEquals("ru-RU,ru;q=0.8,en-US;q=0.5,en;q=0.3",
+                upstreamRequest.getHeader(HttpHeaders.ACCEPT_LANGUAGE));
+        assertEquals("Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:143.0) Gecko/20100101 Firefox/143.0",
+                upstreamRequest.getHeader(HttpHeaders.USER_AGENT));
 
         var jwtClaims = decodeJwtPayload(jwt);
         assertEquals(jwtClaims.get("sub").asText(),
@@ -204,21 +212,21 @@ class WachterIntegrationTest extends AbstractKeycloakOpenIdAsWiremockConfig {
                     headers.set("Service", "MerchantStatistics");
 
                     // Mixed woody and x-woody headers
-                    headers.set("woody.trace-id", "GZvsthKQAAA");
-                    headers.set("x-woody-span-id", "GZvsthKQBBB");
-                    headers.set("woody.parent-id", "parent-woody");
-                    headers.set("x-woody-deadline", deadline.toString());
+                    headers.set(WOODY_TRACE_ID, "GZvsthKQAAA");
+                    headers.set(X_WOODY_SPAN_ID, "GZvsthKQBBB");
+                    headers.set(WOODY_PARENT_ID, "parent-woody");
+                    headers.set(X_WOODY_DEADLINE, deadline.toString());
 
                     // User identity in different formats
-                    headers.set("woody.meta.user-identity.realm", "/woody-realm");
-                    headers.set("x-woody-meta-user-identity-id", "header-user-id");
+                    headers.set(WOODY_META_USER_IDENTITY_PREFIX + "realm", "/woody-realm");
+                    headers.set(X_WOODY_META_USER_IDENTITY_PREFIX + "id", "header-user-id");
 
                     // Request metadata
                     headers.set(X_REQUEST_ID, "mixed-request-id");
                     headers.set(X_REQUEST_DEADLINE, deadline.toString());
 
                     // Traceparent
-                    headers.set("traceparent", "00-" + otelTraceId + "-9cfa814ae977266e-01");
+                    headers.set(OTEL_TRACE_PARENT, "00-" + otelTraceId + "-9cfa814ae977266e-01");
                 })
                 .body(payload)
                 .retrieve()

--- a/src/test/java/dev/vality/wachter/integration/WachterIntegrationTest.java
+++ b/src/test/java/dev/vality/wachter/integration/WachterIntegrationTest.java
@@ -174,8 +174,8 @@ class WachterIntegrationTest extends AbstractKeycloakOpenIdAsWiremockConfig {
         assertNotNull(upstreamRequest.getHeader(OTEL_TRACE_PARENT));
         assertTrue(upstreamRequest.getHeader(OTEL_TRACE_PARENT).matches(TRACEPARENT_PATTERN));
 
-        assertEquals(requestId, upstreamRequest.getHeader(X_REQUEST_ID));
-        assertEquals(deadline.toString(), upstreamRequest.getHeader(X_REQUEST_DEADLINE));
+        assertEquals(requestId, upstreamRequest.getHeader(WOODY_META_REQUEST_ID));
+        assertEquals(deadline.toString(), upstreamRequest.getHeader(WOODY_META_REQUEST_DEADLINE));
 
         assertFalse(upstreamRequest.containsHeader("cf-ray"));
         assertFalse(upstreamRequest.containsHeader("cdn-loop"));
@@ -259,8 +259,8 @@ class WachterIntegrationTest extends AbstractKeycloakOpenIdAsWiremockConfig {
         assertTrue(upstreamRequest.getHeader(OTEL_TRACE_PARENT).contains(otelTraceId));
 
         // Request metadata should be preserved
-        assertEquals("mixed-request-id", upstreamRequest.getHeader(X_REQUEST_ID));
-        assertEquals(deadline.toString(), upstreamRequest.getHeader(X_REQUEST_DEADLINE));
+        assertEquals("mixed-request-id", upstreamRequest.getHeader(WOODY_META_REQUEST_ID));
+        assertEquals(deadline.toString(), upstreamRequest.getHeader(WOODY_META_REQUEST_DEADLINE));
     }
 
     @Test

--- a/src/test/java/dev/vality/wachter/integration/WachterIntegrationTest.java
+++ b/src/test/java/dev/vality/wachter/integration/WachterIntegrationTest.java
@@ -1,5 +1,7 @@
 package dev.vality.wachter.integration;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import dev.vality.wachter.config.AbstractKeycloakOpenIdAsWiremockConfig;
@@ -10,7 +12,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -21,6 +23,7 @@ import org.springframework.web.client.RestClient;
 
 import java.net.http.HttpClient;
 import java.time.Instant;
+import java.util.Base64;
 import java.util.List;
 import java.util.UUID;
 
@@ -29,15 +32,16 @@ import static dev.vality.wachter.constants.TraceHeadersConstants.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 @TestPropertySource(properties = {
-        "wachter.services.Domain.url=http://localhost:${wiremock.server.port}/domain",
-        "wachter.services.Deanonimus.url=http://localhost:${wiremock.server.port}/deanonimus",
-        "wachter.services.MerchantStatistics.url=http://localhost:${wiremock.server.port}/magista"
+        "wachter.services.Domain.url=${wiremock.server.baseUrl}/domain",
+        "wachter.services.Deanonimus.url=${wiremock.server.baseUrl}/deanonimus",
+        "wachter.services.MerchantStatistics.url=${wiremock.server.baseUrl}/magista"
 })
 class WachterIntegrationTest extends AbstractKeycloakOpenIdAsWiremockConfig {
 
     private static final String TRACEPARENT_PATTERN = "00-[0-9a-f]{32}-[0-9a-f]{16}-0[0-1]";
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
-    @LocalServerPort
+    @Value("${server.port}")
     private int port;
 
     private RestClient restClient;
@@ -46,7 +50,7 @@ class WachterIntegrationTest extends AbstractKeycloakOpenIdAsWiremockConfig {
     private TProtocolFactory protocolFactory;
 
     @BeforeEach
-    void setUpRestClient() {
+    void setUp() {
         restClient = RestClient.builder()
                 .baseUrl("http://localhost:" + port)
                 .defaultStatusHandler(status -> true, (request, response) -> {
@@ -65,24 +69,28 @@ class WachterIntegrationTest extends AbstractKeycloakOpenIdAsWiremockConfig {
 
     @Test
     void shouldProxyRequestWithCompleteTracingHeaders() throws Exception {
-        final var traceId = "GZyWNGugAAA";
-        final var spanId = "GZyWNGugBBB";
-        final var parentId = "undefined";
-        final var deadline = Instant.now().plusSeconds(300);
-        final var requestId = UUID.randomUUID().toString();
-        final var payload = TMessageUtil.createTMessage(protocolFactory);
-        final var responseBody = "integration-response".getBytes();
-        final var upstreamTraceparent = "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01";
+        var traceId = "GZyWNGugAAA";
+        var spanId = "GZyWNGugBBB";
+        var parentId = "undefined";
+        var deadline = Instant.now().plusSeconds(300);
+        var requestId = UUID.randomUUID().toString();
+        var payload = TMessageUtil.createTMessage(protocolFactory);
+        var responseBody = "integration-response".getBytes();
+        var upstreamTraceparent = "00-cfa3d3072a4e3e99fc14829a65311819-6e4609576fa4d077-01";
+        var jwt = generateSimpleJwtWithRoles();
 
         stubFor(post(urlEqualTo("/deanonimus"))
                 .withRequestBody(binaryEqualTo(payload))
                 .willReturn(aResponse()
                         .withStatus(HttpStatus.OK.value())
+                        .withHeader("woody.trace-id", traceId)
+                        .withHeader("woody.parent-id", parentId)
+                        .withHeader("woody.span-id", spanId)
                         .withHeader("traceparent", upstreamTraceparent)
                         .withHeader(HttpHeaders.CONTENT_TYPE, "application/x-thrift")
                         .withBody(responseBody)));
 
-        final ResponseEntity<byte[]> response = restClient.post()
+        var response = restClient.post()
                 .uri("/wachter")
                 .contentType(MediaType.valueOf("application/x-thrift"))
                 .headers(headers -> {
@@ -111,7 +119,7 @@ class WachterIntegrationTest extends AbstractKeycloakOpenIdAsWiremockConfig {
                     headers.set("x-forwarded-proto", "https");
 
                     // Authentication and service
-                    headers.set("Authorization", "Bearer " + generateSimpleJwtWithRoles());
+                    headers.set("Authorization", "Bearer " + jwt);
                     headers.set("Service", "Deanonimus");
 
                     // Woody tracing headers
@@ -119,13 +127,14 @@ class WachterIntegrationTest extends AbstractKeycloakOpenIdAsWiremockConfig {
                     headers.set("x-woody-span-id", spanId);
                     headers.set("x-woody-parent-id", parentId);
                     headers.set("x-woody-meta-user-identity-id", "b54a93c4-415d-4f33-a5e9-3608fd043ff4");
-                    headers.set("x-woody-meta-user-identity-username", "e.cherniak@empayre.com");
-                    headers.set("x-woody-meta-user-identity-email", "e.cherniak@empayre.com");
+                    headers.set("x-woody-meta-user-identity-username", "noreply@empayre.com");
+                    headers.set("x-woody-meta-user-identity-email", "noreply@empayre.com");
                     headers.set("x-woody-meta-user-identity-realm", "internal");
 
                     // Request metadata
                     headers.set(X_REQUEST_ID, requestId);
                     headers.set(X_REQUEST_DEADLINE, deadline.toString());
+                    headers.set("traceparent", upstreamTraceparent);
                 })
                 .body(payload)
                 .retrieve()
@@ -135,33 +144,31 @@ class WachterIntegrationTest extends AbstractKeycloakOpenIdAsWiremockConfig {
         assertEquals(upstreamTraceparent, response.getHeaders().getFirst("traceparent"));
         assertArrayEquals(responseBody, response.getBody());
 
-        // Verify upstream request headers
         List<LoggedRequest> requests = findAll(postRequestedFor(urlEqualTo("/deanonimus")));
         assertEquals(1, requests.size());
         LoggedRequest upstreamRequest = requests.get(0);
 
-        // Verify woody tracing headers were sent
         assertEquals(traceId, upstreamRequest.getHeader(WOODY_TRACE_ID));
         assertEquals(spanId, upstreamRequest.getHeader(WOODY_SPAN_ID));
         assertEquals(parentId, upstreamRequest.getHeader(WOODY_PARENT_ID));
         assertTrue(upstreamRequest.containsHeader(WOODY_DEADLINE));
 
-        // Verify user identity metadata was sent (from headers, not JWT because headers take precedence)
-        assertEquals("b54a93c4-415d-4f33-a5e9-3608fd043ff4",
+        var jwtClaims = decodeJwtPayload(jwt);
+        assertEquals(jwtClaims.get("sub").asText(),
                 upstreamRequest.getHeader(WOODY_META_USER_IDENTITY_PREFIX + "id"));
-        assertEquals("e.cherniak@empayre.com", upstreamRequest.getHeader(WOODY_META_USER_IDENTITY_PREFIX + "username"));
-        assertEquals("e.cherniak@empayre.com", upstreamRequest.getHeader(WOODY_META_USER_IDENTITY_PREFIX + "email"));
-        assertEquals("internal", upstreamRequest.getHeader(WOODY_META_USER_IDENTITY_PREFIX + "realm"));
+        assertEquals(jwtClaims.get("preferred_username").asText(),
+                upstreamRequest.getHeader(WOODY_META_USER_IDENTITY_PREFIX + "username"));
+        assertEquals(jwtClaims.get("email").asText(),
+                upstreamRequest.getHeader(WOODY_META_USER_IDENTITY_PREFIX + "email"));
+        assertEquals(extractRealm(jwtClaims),
+                upstreamRequest.getHeader(WOODY_META_USER_IDENTITY_PREFIX + "realm"));
 
-        // Verify OpenTelemetry traceparent was sent
         assertNotNull(upstreamRequest.getHeader(OTEL_TRACE_PARENT));
         assertTrue(upstreamRequest.getHeader(OTEL_TRACE_PARENT).matches(TRACEPARENT_PATTERN));
 
-        // Verify request metadata was sent
         assertEquals(requestId, upstreamRequest.getHeader(X_REQUEST_ID));
         assertEquals(deadline.toString(), upstreamRequest.getHeader(X_REQUEST_DEADLINE));
 
-        // Verify browser/CDN headers were NOT sent
         assertFalse(upstreamRequest.containsHeader("cf-ray"));
         assertFalse(upstreamRequest.containsHeader("cdn-loop"));
         assertFalse(upstreamRequest.containsHeader("cf-visitor"));
@@ -178,6 +185,9 @@ class WachterIntegrationTest extends AbstractKeycloakOpenIdAsWiremockConfig {
         final var deadline = Instant.now().plusSeconds(300);
         final var payload = TMessageUtil.createTMessage(protocolFactory);
         final var responseBody = "test-response".getBytes();
+        final var jwt = generateSimpleJwtWithRoles();
+        final var jwtClaims = decodeJwtPayload(jwt);
+        var otelTraceId = "3d8202ad198e4d37771c995246e1b356";
 
         stubFor(post(urlEqualTo("/magista"))
                 .withRequestBody(binaryEqualTo(payload))
@@ -190,8 +200,8 @@ class WachterIntegrationTest extends AbstractKeycloakOpenIdAsWiremockConfig {
                 .uri("/wachter")
                 .contentType(MediaType.valueOf("application/x-thrift"))
                 .headers(headers -> {
-                    headers.set("Authorization", "Bearer " + generateSimpleJwtWithRoles());
-                    headers.set("Service", "Domain");
+                    headers.set("Authorization", "Bearer " + jwt);
+                    headers.set("Service", "MerchantStatistics");
 
                     // Mixed woody and x-woody headers
                     headers.set("woody.trace-id", "GZvsthKQAAA");
@@ -208,7 +218,7 @@ class WachterIntegrationTest extends AbstractKeycloakOpenIdAsWiremockConfig {
                     headers.set(X_REQUEST_DEADLINE, deadline.toString());
 
                     // Traceparent
-                    headers.set("traceparent", "00-abc123def456789012345678901234-fedcba9876543210-01");
+                    headers.set("traceparent", "00-" + otelTraceId + "-9cfa814ae977266e-01");
                 })
                 .body(payload)
                 .retrieve()
@@ -228,16 +238,17 @@ class WachterIntegrationTest extends AbstractKeycloakOpenIdAsWiremockConfig {
         assertEquals("parent-woody", upstreamRequest.getHeader(WOODY_PARENT_ID));
         assertNotNull(upstreamRequest.getHeader(WOODY_DEADLINE));
 
-        // User identity should combine headers and JWT data (header-user-id from header, others from JWT)
-        assertEquals("header-user-id", upstreamRequest.getHeader(WOODY_META_USER_IDENTITY_PREFIX + "id"));
-        assertEquals("Darth Vader", upstreamRequest.getHeader(WOODY_META_USER_IDENTITY_PREFIX + "username"));
-        assertEquals("darkside-the-best@mail.com",
+        // User identity metadata should be sourced from JWT when present
+        assertEquals(jwtClaims.get("sub").asText(), upstreamRequest.getHeader(WOODY_META_USER_IDENTITY_PREFIX + "id"));
+        assertEquals(jwtClaims.get("preferred_username").asText(),
+                upstreamRequest.getHeader(WOODY_META_USER_IDENTITY_PREFIX + "username"));
+        assertEquals(jwtClaims.get("email").asText(),
                 upstreamRequest.getHeader(WOODY_META_USER_IDENTITY_PREFIX + "email"));
-        assertEquals("/woody-realm", upstreamRequest.getHeader(WOODY_META_USER_IDENTITY_PREFIX + "realm"));
+        assertEquals(extractRealm(jwtClaims),
+                upstreamRequest.getHeader(WOODY_META_USER_IDENTITY_PREFIX + "realm"));
 
         // Traceparent should be preserved
-        assertEquals("00-abc123def456789012345678901234-fedcba9876543210-01",
-                upstreamRequest.getHeader(OTEL_TRACE_PARENT));
+        assertTrue(upstreamRequest.getHeader(OTEL_TRACE_PARENT).contains(otelTraceId));
 
         // Request metadata should be preserved
         assertEquals("mixed-request-id", upstreamRequest.getHeader(X_REQUEST_ID));
@@ -338,5 +349,31 @@ class WachterIntegrationTest extends AbstractKeycloakOpenIdAsWiremockConfig {
         assertEquals(HttpStatus.BAD_GATEWAY, response.getStatusCode());
         assertEquals("*", response.getHeaders().getFirst(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN));
         assertNull(response.getHeaders().getFirst(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS));
+    }
+
+    private static JsonNode decodeJwtPayload(String jwt) {
+        var parts = jwt.split("\\.");
+        if (parts.length < 2) {
+            throw new IllegalArgumentException("Invalid JWT");
+        }
+        var payload = new String(Base64.getUrlDecoder().decode(parts[1]));
+        try {
+            return OBJECT_MAPPER.readTree(payload);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Invalid JWT payload", e);
+        }
+    }
+
+    private static String extractRealm(JsonNode jwtClaims) {
+        var issuerNode = jwtClaims.get("iss");
+        if (issuerNode == null || issuerNode.isNull()) {
+            return null;
+        }
+        var issuer = issuerNode.asText();
+        if (issuer.isBlank()) {
+            return null;
+        }
+        var lastSlash = issuer.lastIndexOf('/');
+        return lastSlash >= 0 ? issuer.substring(lastSlash) : issuer;
     }
 }

--- a/src/test/java/dev/vality/wachter/tracing/TraceContextHeadersExtractorTest.java
+++ b/src/test/java/dev/vality/wachter/tracing/TraceContextHeadersExtractorTest.java
@@ -173,15 +173,15 @@ class TraceContextHeadersExtractorTest {
         span.setParentId("undefined");
 
         activeSpan.getCustomMetadata().putValue(UserIdentityIdExtensionKit.KEY, "b54a93c4-415d-4f33-a5e9-3608fd043ff4");
-        activeSpan.getCustomMetadata().putValue(UserIdentityUsernameExtensionKit.KEY, "noreply@empayre.com");
-        activeSpan.getCustomMetadata().putValue(UserIdentityEmailExtensionKit.KEY, "noreply@empayre.com");
+        activeSpan.getCustomMetadata().putValue(UserIdentityUsernameExtensionKit.KEY, "noreply@valitydev.com");
+        activeSpan.getCustomMetadata().putValue(UserIdentityEmailExtensionKit.KEY, "noreply@valitydev.com");
         activeSpan.getCustomMetadata().putValue(UserIdentityRealmExtensionKit.KEY, "/internal");
 
         final Map<String, String> headers = TraceContextHeadersExtractor.extractHeaders();
 
         assertEquals("b54a93c4-415d-4f33-a5e9-3608fd043ff4", headers.get(WOODY_META_USER_IDENTITY_PREFIX + "id"));
-        assertEquals("noreply@empayre.com", headers.get(WOODY_META_USER_IDENTITY_PREFIX + "username"));
-        assertEquals("noreply@empayre.com", headers.get(WOODY_META_USER_IDENTITY_PREFIX + "email"));
+        assertEquals("noreply@valitydev.com", headers.get(WOODY_META_USER_IDENTITY_PREFIX + "username"));
+        assertEquals("noreply@valitydev.com", headers.get(WOODY_META_USER_IDENTITY_PREFIX + "email"));
         assertEquals("/internal", headers.get(WOODY_META_USER_IDENTITY_PREFIX + "realm"));
 
         otelSpan.end();
@@ -225,8 +225,8 @@ class TraceContextHeadersExtractorTest {
 
         final var metadata = activeSpan.getCustomMetadata();
         metadata.putValue(UserIdentityIdExtensionKit.KEY, "b54a93c4-415d-4f33-a5e9-3608fd043ff4");
-        metadata.putValue(UserIdentityUsernameExtensionKit.KEY, "noreply@empayre.com");
-        metadata.putValue(UserIdentityEmailExtensionKit.KEY, "noreply@empayre.com");
+        metadata.putValue(UserIdentityUsernameExtensionKit.KEY, "noreply@valitydev.com");
+        metadata.putValue(UserIdentityEmailExtensionKit.KEY, "noreply@valitydev.com");
         metadata.putValue(UserIdentityRealmExtensionKit.KEY, "/internal");
         metadata.putValue(X_REQUEST_ID, "req-12345");
         metadata.putValue(X_REQUEST_DEADLINE, "2030-01-01T00:00:00Z");
@@ -238,8 +238,8 @@ class TraceContextHeadersExtractorTest {
         assertEquals("undefined", headers.get(WOODY_PARENT_ID));
         assertEquals("2030-01-01T00:00:00Z", headers.get(WOODY_DEADLINE));
         assertEquals("b54a93c4-415d-4f33-a5e9-3608fd043ff4", headers.get(WOODY_META_USER_IDENTITY_PREFIX + "id"));
-        assertEquals("noreply@empayre.com", headers.get(WOODY_META_USER_IDENTITY_PREFIX + "username"));
-        assertEquals("noreply@empayre.com", headers.get(WOODY_META_USER_IDENTITY_PREFIX + "email"));
+        assertEquals("noreply@valitydev.com", headers.get(WOODY_META_USER_IDENTITY_PREFIX + "username"));
+        assertEquals("noreply@valitydev.com", headers.get(WOODY_META_USER_IDENTITY_PREFIX + "email"));
         assertEquals("/internal", headers.get(WOODY_META_USER_IDENTITY_PREFIX + "realm"));
         assertEquals("req-12345", headers.get(WOODY_META_REQUEST_ID));
         assertEquals("2030-01-01T00:00:00Z", headers.get(WOODY_META_REQUEST_DEADLINE));

--- a/src/test/java/dev/vality/wachter/tracing/TraceContextHeadersExtractorTest.java
+++ b/src/test/java/dev/vality/wachter/tracing/TraceContextHeadersExtractorTest.java
@@ -117,8 +117,8 @@ class TraceContextHeadersExtractorTest {
 
         final Map<String, String> headers = TraceContextHeadersExtractor.extractHeaders();
 
-        assertEquals("request-123", headers.get(X_REQUEST_ID));
-        assertEquals("2030-12-31T23:59:59Z", headers.get(X_REQUEST_DEADLINE));
+        assertEquals("request-123", headers.get(WOODY_META_REQUEST_ID));
+        assertEquals("2030-12-31T23:59:59Z", headers.get(WOODY_META_REQUEST_DEADLINE));
 
         otelSpan.end();
     }
@@ -241,8 +241,8 @@ class TraceContextHeadersExtractorTest {
         assertEquals("noreply@empayre.com", headers.get(WOODY_META_USER_IDENTITY_PREFIX + "username"));
         assertEquals("noreply@empayre.com", headers.get(WOODY_META_USER_IDENTITY_PREFIX + "email"));
         assertEquals("/internal", headers.get(WOODY_META_USER_IDENTITY_PREFIX + "realm"));
-        assertEquals("req-12345", headers.get(X_REQUEST_ID));
-        assertEquals("2030-01-01T00:00:00Z", headers.get(X_REQUEST_DEADLINE));
+        assertEquals("req-12345", headers.get(WOODY_META_REQUEST_ID));
+        assertEquals("2030-01-01T00:00:00Z", headers.get(WOODY_META_REQUEST_DEADLINE));
         assertNotNull(headers.get(OTEL_TRACE_PARENT));
 
         otelSpan.end();

--- a/src/test/java/dev/vality/wachter/tracing/TraceContextHeadersExtractorTest.java
+++ b/src/test/java/dev/vality/wachter/tracing/TraceContextHeadersExtractorTest.java
@@ -1,6 +1,5 @@
-package dev.vality.wachter.config.tracing;
+package dev.vality.wachter.tracing;
 
-import dev.vality.wachter.tracing.TraceContextHeadersExtractor;
 import dev.vality.woody.api.flow.WFlow;
 import dev.vality.woody.api.trace.TraceData;
 import dev.vality.woody.api.trace.context.TraceContext;
@@ -174,15 +173,15 @@ class TraceContextHeadersExtractorTest {
         span.setParentId("undefined");
 
         activeSpan.getCustomMetadata().putValue(UserIdentityIdExtensionKit.KEY, "b54a93c4-415d-4f33-a5e9-3608fd043ff4");
-        activeSpan.getCustomMetadata().putValue(UserIdentityUsernameExtensionKit.KEY, "e.cherniak@empayre.com");
-        activeSpan.getCustomMetadata().putValue(UserIdentityEmailExtensionKit.KEY, "e.cherniak@empayre.com");
+        activeSpan.getCustomMetadata().putValue(UserIdentityUsernameExtensionKit.KEY, "noreply@empayre.com");
+        activeSpan.getCustomMetadata().putValue(UserIdentityEmailExtensionKit.KEY, "noreply@empayre.com");
         activeSpan.getCustomMetadata().putValue(UserIdentityRealmExtensionKit.KEY, "/internal");
 
         final Map<String, String> headers = TraceContextHeadersExtractor.extractHeaders();
 
         assertEquals("b54a93c4-415d-4f33-a5e9-3608fd043ff4", headers.get(WOODY_META_USER_IDENTITY_PREFIX + "id"));
-        assertEquals("e.cherniak@empayre.com", headers.get(WOODY_META_USER_IDENTITY_PREFIX + "username"));
-        assertEquals("e.cherniak@empayre.com", headers.get(WOODY_META_USER_IDENTITY_PREFIX + "email"));
+        assertEquals("noreply@empayre.com", headers.get(WOODY_META_USER_IDENTITY_PREFIX + "username"));
+        assertEquals("noreply@empayre.com", headers.get(WOODY_META_USER_IDENTITY_PREFIX + "email"));
         assertEquals("/internal", headers.get(WOODY_META_USER_IDENTITY_PREFIX + "realm"));
 
         otelSpan.end();
@@ -226,8 +225,8 @@ class TraceContextHeadersExtractorTest {
 
         final var metadata = activeSpan.getCustomMetadata();
         metadata.putValue(UserIdentityIdExtensionKit.KEY, "b54a93c4-415d-4f33-a5e9-3608fd043ff4");
-        metadata.putValue(UserIdentityUsernameExtensionKit.KEY, "e.cherniak@empayre.com");
-        metadata.putValue(UserIdentityEmailExtensionKit.KEY, "e.cherniak@empayre.com");
+        metadata.putValue(UserIdentityUsernameExtensionKit.KEY, "noreply@empayre.com");
+        metadata.putValue(UserIdentityEmailExtensionKit.KEY, "noreply@empayre.com");
         metadata.putValue(UserIdentityRealmExtensionKit.KEY, "/internal");
         metadata.putValue(X_REQUEST_ID, "req-12345");
         metadata.putValue(X_REQUEST_DEADLINE, "2030-01-01T00:00:00Z");
@@ -239,8 +238,8 @@ class TraceContextHeadersExtractorTest {
         assertEquals("undefined", headers.get(WOODY_PARENT_ID));
         assertEquals("2030-01-01T00:00:00Z", headers.get(WOODY_DEADLINE));
         assertEquals("b54a93c4-415d-4f33-a5e9-3608fd043ff4", headers.get(WOODY_META_USER_IDENTITY_PREFIX + "id"));
-        assertEquals("e.cherniak@empayre.com", headers.get(WOODY_META_USER_IDENTITY_PREFIX + "username"));
-        assertEquals("e.cherniak@empayre.com", headers.get(WOODY_META_USER_IDENTITY_PREFIX + "email"));
+        assertEquals("noreply@empayre.com", headers.get(WOODY_META_USER_IDENTITY_PREFIX + "username"));
+        assertEquals("noreply@empayre.com", headers.get(WOODY_META_USER_IDENTITY_PREFIX + "email"));
         assertEquals("/internal", headers.get(WOODY_META_USER_IDENTITY_PREFIX + "realm"));
         assertEquals("req-12345", headers.get(X_REQUEST_ID));
         assertEquals("2030-01-01T00:00:00Z", headers.get(X_REQUEST_DEADLINE));
@@ -252,6 +251,7 @@ class TraceContextHeadersExtractorTest {
     @Test
     void shouldThrowWhenTraceDataIsNull() {
         TraceContext.setCurrentTraceData(null);
+        TraceContext.getCurrentTraceData().setOtelSpan(null);
 
         assertThrows(NullPointerException.class, () -> {
             TraceContextHeadersExtractor.extractHeaders();
@@ -261,6 +261,7 @@ class TraceContextHeadersExtractorTest {
     @Test
     void shouldThrowWhenOtelSpanIsNull() {
         final var traceData = new TraceData();
+        traceData.setOtelSpan(null);
         TraceContext.setCurrentTraceData(traceData);
 
         assertThrows(NullPointerException.class, () -> {

--- a/src/test/java/dev/vality/wachter/tracing/TraceContextHeadersNormalizerTest.java
+++ b/src/test/java/dev/vality/wachter/tracing/TraceContextHeadersNormalizerTest.java
@@ -252,7 +252,7 @@ class TraceContextHeadersNormalizerTest {
         when(request.getHeader(WOODY_TRACE_ID)).thenReturn("GZyWNGugAAA");
         when(request.getHeader(X_WOODY_SPAN_ID)).thenReturn("GZyWNGugBBB");
         when(request.getHeader(X_WOODY_PARENT_ID)).thenReturn("undefined");
-        when(request.getHeader(X_WOODY_META_USER_IDENTITY_PREFIX + "email")).thenReturn("noreply@empayre.com");
+        when(request.getHeader(X_WOODY_META_USER_IDENTITY_PREFIX + "email")).thenReturn("noreply@valitydev.com");
         when(request.getHeader(OTEL_TRACE_PARENT)).thenReturn(
                 "00-cfa3d3072a4e3e99fc14829a65311819-6e4609576fa4d077-01");
         when(request.getHeader(X_REQUEST_ID)).thenReturn("req-complex");
@@ -264,8 +264,8 @@ class TraceContextHeadersNormalizerTest {
         try (MockedStatic<JwtTokenDetailsExtractor> extractor = mockStatic(JwtTokenDetailsExtractor.class)) {
             var tokenDetails = new JwtTokenDetails(
                     "b54a93c4-415d-4f33-a5e9-3608fd043ff4",
-                    "noreply@empayre.com",
-                    "noreply@empayre.com",
+                    "noreply@valitydev.com",
+                    "noreply@valitydev.com",
                     "/internal",
                     List.of("ROLE_USER")
             );
@@ -277,10 +277,10 @@ class TraceContextHeadersNormalizerTest {
             assertEquals("GZyWNGugAAA", normalized.get(WOODY_TRACE_ID));
             assertEquals("GZyWNGugBBB", normalized.get(WOODY_SPAN_ID));
             assertEquals("undefined", normalized.get(WOODY_PARENT_ID));
-            assertEquals("noreply@empayre.com", normalized.get(WOODY_META_USER_IDENTITY_PREFIX + "email"));
+            assertEquals("noreply@valitydev.com", normalized.get(WOODY_META_USER_IDENTITY_PREFIX + "email"));
             assertEquals("b54a93c4-415d-4f33-a5e9-3608fd043ff4",
                     normalized.get(WOODY_META_USER_IDENTITY_PREFIX + "id"));
-            assertEquals("noreply@empayre.com", normalized.get(WOODY_META_USER_IDENTITY_PREFIX + "username"));
+            assertEquals("noreply@valitydev.com", normalized.get(WOODY_META_USER_IDENTITY_PREFIX + "username"));
             assertEquals("/internal", normalized.get(WOODY_META_USER_IDENTITY_PREFIX + "realm"));
             assertEquals("00-cfa3d3072a4e3e99fc14829a65311819-6e4609576fa4d077-01", normalized.get(OTEL_TRACE_PARENT));
             assertEquals("2030-01-01T00:00:00Z", normalized.get(WOODY_DEADLINE));

--- a/src/test/java/dev/vality/wachter/tracing/TraceContextHeadersNormalizerTest.java
+++ b/src/test/java/dev/vality/wachter/tracing/TraceContextHeadersNormalizerTest.java
@@ -1,0 +1,321 @@
+package dev.vality.wachter.tracing;
+
+import dev.vality.wachter.security.JwtTokenDetailsExtractor;
+import dev.vality.wachter.security.JwtTokenDetailsExtractor.JwtTokenDetails;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static dev.vality.wachter.constants.TraceHeadersConstants.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TraceContextHeadersNormalizerTest {
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private SecurityContext securityContext;
+
+    @Mock
+    private Authentication authentication;
+
+    @BeforeEach
+    void setUp() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void shouldNormalizeWoodyHeadersFromLowercase() {
+        when(request.getHeaderNames()).thenReturn(Collections.enumeration(List.of(
+                WOODY_TRACE_ID, WOODY_SPAN_ID, WOODY_PARENT_ID, WOODY_DEADLINE
+        )));
+        when(request.getHeader(WOODY_TRACE_ID)).thenReturn("trace-123");
+        when(request.getHeader(WOODY_SPAN_ID)).thenReturn("span-456");
+        when(request.getHeader(WOODY_PARENT_ID)).thenReturn("parent-789");
+        when(request.getHeader(WOODY_DEADLINE)).thenReturn("2030-01-01T00:00:00Z");
+
+        var normalized = TraceContextHeadersNormalizer.normalize(request);
+
+        assertEquals("trace-123", normalized.get(WOODY_TRACE_ID));
+        assertEquals("span-456", normalized.get(WOODY_SPAN_ID));
+        assertEquals("parent-789", normalized.get(WOODY_PARENT_ID));
+        assertEquals("2030-01-01T00:00:00Z", normalized.get(WOODY_DEADLINE));
+    }
+
+    @Test
+    void shouldNormalizeXWoodyHeadersToWoody() {
+        when(request.getHeaderNames()).thenReturn(Collections.enumeration(List.of(
+                X_WOODY_TRACE_ID, X_WOODY_SPAN_ID, X_WOODY_PARENT_ID
+        )));
+        when(request.getHeader(X_WOODY_TRACE_ID)).thenReturn("trace-123");
+        when(request.getHeader(X_WOODY_SPAN_ID)).thenReturn("span-456");
+        when(request.getHeader(X_WOODY_PARENT_ID)).thenReturn("parent-789");
+
+        var normalized = TraceContextHeadersNormalizer.normalize(request);
+
+        assertEquals("trace-123", normalized.get(WOODY_TRACE_ID));
+        assertEquals("span-456", normalized.get(WOODY_SPAN_ID));
+        assertEquals("parent-789", normalized.get(WOODY_PARENT_ID));
+    }
+
+    @Test
+    void shouldNormalizeUserIdentityMetadataFromXWoody() {
+        when(request.getHeaderNames()).thenReturn(Collections.enumeration(List.of(
+                X_WOODY_META_USER_IDENTITY_PREFIX + "id",
+                X_WOODY_META_USER_IDENTITY_PREFIX + "username",
+                X_WOODY_META_USER_IDENTITY_PREFIX + "email",
+                X_WOODY_META_USER_IDENTITY_PREFIX + "realm"
+        )));
+        when(request.getHeader(X_WOODY_META_USER_IDENTITY_PREFIX + "id")).thenReturn("user-id-123");
+        when(request.getHeader(X_WOODY_META_USER_IDENTITY_PREFIX + "username")).thenReturn("john.doe");
+        when(request.getHeader(X_WOODY_META_USER_IDENTITY_PREFIX + "email")).thenReturn("john@example.com");
+        when(request.getHeader(X_WOODY_META_USER_IDENTITY_PREFIX + "realm")).thenReturn("/internal");
+
+        var normalized = TraceContextHeadersNormalizer.normalize(request);
+
+        assertEquals("user-id-123", normalized.get(WOODY_META_USER_IDENTITY_PREFIX + "id"));
+        assertEquals("john.doe", normalized.get(WOODY_META_USER_IDENTITY_PREFIX + "username"));
+        assertEquals("john@example.com", normalized.get(WOODY_META_USER_IDENTITY_PREFIX + "email"));
+        assertEquals("/internal", normalized.get(WOODY_META_USER_IDENTITY_PREFIX + "realm"));
+    }
+
+    @Test
+    void shouldNormalizeTraceparentHeader() {
+        when(request.getHeaderNames()).thenReturn(Collections.enumeration(List.of(OTEL_TRACE_PARENT)));
+        when(request.getHeader(OTEL_TRACE_PARENT)).thenReturn("00-123abc-456def-01");
+
+        var normalized = TraceContextHeadersNormalizer.normalize(request);
+
+        assertEquals("00-123abc-456def-01", normalized.get(OTEL_TRACE_PARENT));
+    }
+
+    @Test
+    void shouldMergeJwtMetadataIntoHeaders() {
+        when(request.getHeaderNames()).thenReturn(Collections.enumeration(Collections.emptyList()));
+        SecurityContextHolder.setContext(securityContext);
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+
+        try (MockedStatic<JwtTokenDetailsExtractor> extractor = mockStatic(JwtTokenDetailsExtractor.class)) {
+            var tokenDetails = new JwtTokenDetails(
+                    "user-jwt-id",
+                    "jwt-username",
+                    "jwt@email.com",
+                    "/jwt-realm",
+                    List.of("ROLE_USER")
+            );
+            extractor.when(() -> JwtTokenDetailsExtractor.extractFromContext(authentication))
+                    .thenReturn(Optional.of(tokenDetails));
+
+            var normalized = TraceContextHeadersNormalizer.normalize(request);
+
+            assertEquals("user-jwt-id", normalized.get(WOODY_META_USER_IDENTITY_PREFIX + "id"));
+            assertEquals("jwt-username", normalized.get(WOODY_META_USER_IDENTITY_PREFIX + "username"));
+            assertEquals("jwt@email.com", normalized.get(WOODY_META_USER_IDENTITY_PREFIX + "email"));
+            assertEquals("/jwt-realm", normalized.get(WOODY_META_USER_IDENTITY_PREFIX + "realm"));
+        }
+    }
+
+    @Test
+    void shouldMergeJwtMetadataWithHeaders() {
+        when(request.getHeaderNames()).thenReturn(Collections.enumeration(List.of(
+                X_WOODY_META_USER_IDENTITY_PREFIX + "id"
+        )));
+        when(request.getHeader(X_WOODY_META_USER_IDENTITY_PREFIX + "id")).thenReturn("header-user-id");
+        when(request.getHeader(OTEL_TRACE_PARENT)).thenReturn(null);
+
+        SecurityContextHolder.setContext(securityContext);
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+
+        try (MockedStatic<JwtTokenDetailsExtractor> extractor = mockStatic(JwtTokenDetailsExtractor.class)) {
+            var tokenDetails = new JwtTokenDetails(
+                    "jwt-user-id",
+                    "jwt-username",
+                    null,
+                    null,
+                    List.of()
+            );
+            extractor.when(() -> JwtTokenDetailsExtractor.extractFromContext(authentication))
+                    .thenReturn(Optional.of(tokenDetails));
+
+            var normalized = TraceContextHeadersNormalizer.normalize(request);
+
+            assertEquals("jwt-user-id", normalized.get(WOODY_META_USER_IDENTITY_PREFIX + "id"));
+            assertEquals("jwt-username", normalized.get(WOODY_META_USER_IDENTITY_PREFIX + "username"));
+        }
+    }
+
+    @Test
+    void shouldMergeRequestDeadlineToWoodyDeadline() {
+        when(request.getHeaderNames()).thenReturn(Collections.enumeration(Collections.emptyList()));
+        when(request.getHeader(X_REQUEST_DEADLINE)).thenReturn("2030-12-31T23:59:59Z");
+        when(request.getHeader(X_REQUEST_ID)).thenReturn(null);
+        when(request.getHeader(OTEL_TRACE_PARENT)).thenReturn(null);
+
+        var normalized = TraceContextHeadersNormalizer.normalize(request);
+
+        assertEquals("2030-12-31T23:59:59Z", normalized.get(WOODY_DEADLINE));
+        assertEquals("2030-12-31T23:59:59Z", normalized.get(X_REQUEST_DEADLINE));
+    }
+
+    @Test
+    void shouldMergeRelativeDeadline() {
+        when(request.getHeaderNames()).thenReturn(Collections.enumeration(Collections.emptyList()));
+        when(request.getHeader(X_REQUEST_DEADLINE)).thenReturn("30s");
+        when(request.getHeader(X_REQUEST_ID)).thenReturn("req-123");
+        when(request.getHeader(OTEL_TRACE_PARENT)).thenReturn(null);
+
+        var normalized = TraceContextHeadersNormalizer.normalize(request);
+
+        assertNotNull(normalized.get(WOODY_DEADLINE));
+        assertEquals(normalized.get(WOODY_DEADLINE), normalized.get(X_REQUEST_DEADLINE));
+        assertTrue(Instant.parse(normalized.get(WOODY_DEADLINE)).isAfter(Instant.now()));
+    }
+
+    @Test
+    void shouldNotOverwriteExistingWoodyDeadline() {
+        when(request.getHeaderNames()).thenReturn(Collections.enumeration(List.of(WOODY_DEADLINE)));
+        when(request.getHeader(WOODY_DEADLINE)).thenReturn("2025-01-01T00:00:00Z");
+        when(request.getHeader(X_REQUEST_DEADLINE)).thenReturn("2030-12-31T23:59:59Z");
+        when(request.getHeader(X_REQUEST_ID)).thenReturn(null);
+        when(request.getHeader(OTEL_TRACE_PARENT)).thenReturn(null);
+
+        var normalized = TraceContextHeadersNormalizer.normalize(request);
+
+        assertEquals("2025-01-01T00:00:00Z", normalized.get(WOODY_DEADLINE));
+        assertEquals("2030-12-31T23:59:59Z", normalized.get(X_REQUEST_DEADLINE));
+    }
+
+    @Test
+    void shouldPreserveRequestIdWithoutDeadline() {
+        when(request.getHeaderNames()).thenReturn(Collections.enumeration(Collections.emptyList()));
+        when(request.getHeader(X_REQUEST_ID)).thenReturn("req-no-deadline");
+        when(request.getHeader(OTEL_TRACE_PARENT)).thenReturn(null);
+        when(request.getHeader(X_REQUEST_DEADLINE)).thenReturn(null);
+
+        var normalized = TraceContextHeadersNormalizer.normalize(request);
+
+        assertEquals("req-no-deadline", normalized.get(X_REQUEST_ID));
+        assertFalse(normalized.containsKey(X_REQUEST_DEADLINE));
+    }
+
+    @Test
+    void shouldHandleEmptyHeaders() {
+        when(request.getHeaderNames()).thenReturn(Collections.enumeration(Collections.emptyList()));
+
+        var normalized = TraceContextHeadersNormalizer.normalize(request);
+
+        assertTrue(normalized.isEmpty());
+    }
+
+    @Test
+    void shouldIgnoreNullHeaderValues() {
+        when(request.getHeaderNames()).thenReturn(Collections.enumeration(List.of(
+                WOODY_TRACE_ID, WOODY_SPAN_ID
+        )));
+        when(request.getHeader(WOODY_TRACE_ID)).thenReturn(null);
+        when(request.getHeader(WOODY_SPAN_ID)).thenReturn("span-456");
+
+        var normalized = TraceContextHeadersNormalizer.normalize(request);
+
+        assertFalse(normalized.containsKey(WOODY_TRACE_ID));
+        assertEquals("span-456", normalized.get(WOODY_SPAN_ID));
+    }
+
+    @Test
+    void shouldHandleComplexScenarioWithAllHeaderTypes() {
+        when(request.getHeaderNames()).thenReturn(Collections.enumeration(List.of(
+                WOODY_TRACE_ID,
+                X_WOODY_SPAN_ID,
+                X_WOODY_PARENT_ID,
+                X_WOODY_META_USER_IDENTITY_PREFIX + "email",
+                OTEL_TRACE_PARENT,
+                "content-type",
+                "authorization"
+        )));
+        when(request.getHeader(WOODY_TRACE_ID)).thenReturn("GZyWNGugAAA");
+        when(request.getHeader(X_WOODY_SPAN_ID)).thenReturn("GZyWNGugBBB");
+        when(request.getHeader(X_WOODY_PARENT_ID)).thenReturn("undefined");
+        when(request.getHeader(X_WOODY_META_USER_IDENTITY_PREFIX + "email")).thenReturn("noreply@empayre.com");
+        when(request.getHeader(OTEL_TRACE_PARENT)).thenReturn(
+                "00-cfa3d3072a4e3e99fc14829a65311819-6e4609576fa4d077-01");
+        when(request.getHeader(X_REQUEST_ID)).thenReturn("req-complex");
+        when(request.getHeader(X_REQUEST_DEADLINE)).thenReturn("2030-01-01T00:00:00Z");
+
+        SecurityContextHolder.setContext(securityContext);
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+
+        try (MockedStatic<JwtTokenDetailsExtractor> extractor = mockStatic(JwtTokenDetailsExtractor.class)) {
+            var tokenDetails = new JwtTokenDetails(
+                    "b54a93c4-415d-4f33-a5e9-3608fd043ff4",
+                    "noreply@empayre.com",
+                    "noreply@empayre.com",
+                    "/internal",
+                    List.of("ROLE_USER")
+            );
+            extractor.when(() -> JwtTokenDetailsExtractor.extractFromContext(authentication))
+                    .thenReturn(Optional.of(tokenDetails));
+
+            var normalized = TraceContextHeadersNormalizer.normalize(request);
+
+            assertEquals("GZyWNGugAAA", normalized.get(WOODY_TRACE_ID));
+            assertEquals("GZyWNGugBBB", normalized.get(WOODY_SPAN_ID));
+            assertEquals("undefined", normalized.get(WOODY_PARENT_ID));
+            assertEquals("noreply@empayre.com", normalized.get(WOODY_META_USER_IDENTITY_PREFIX + "email"));
+            assertEquals("b54a93c4-415d-4f33-a5e9-3608fd043ff4",
+                    normalized.get(WOODY_META_USER_IDENTITY_PREFIX + "id"));
+            assertEquals("noreply@empayre.com", normalized.get(WOODY_META_USER_IDENTITY_PREFIX + "username"));
+            assertEquals("/internal", normalized.get(WOODY_META_USER_IDENTITY_PREFIX + "realm"));
+            assertEquals("00-cfa3d3072a4e3e99fc14829a65311819-6e4609576fa4d077-01", normalized.get(OTEL_TRACE_PARENT));
+            assertEquals("2030-01-01T00:00:00Z", normalized.get(WOODY_DEADLINE));
+            assertEquals("req-complex", normalized.get(X_REQUEST_ID));
+            assertEquals("2030-01-01T00:00:00Z", normalized.get(X_REQUEST_DEADLINE));
+        }
+    }
+
+    @Test
+    void shouldNormalizeResponseHeaders() {
+        var responseHeaders = new HttpHeaders();
+        responseHeaders.add(WOODY_TRACE_ID, "resp-trace");
+        responseHeaders.add(WOODY_SPAN_ID, "resp-span");
+        responseHeaders.add(X_WOODY_PARENT_ID, "resp-parent");
+        responseHeaders.add(WOODY_META_USER_IDENTITY_PREFIX + "id", "resp-user");
+        responseHeaders.add(OTEL_TRACE_PARENT, "00-abc-def-01");
+        responseHeaders.add(X_REQUEST_ID, "resp-req");
+        responseHeaders.add(WOODY_DEADLINE, "2030-01-01T00:00:00Z");
+        responseHeaders.add(WOODY_ERROR_CLASS, "resp-req");
+        responseHeaders.add(WOODY_ERROR_REASON, "resp-req");
+        responseHeaders.add("Content-Type", "application/json");
+        responseHeaders.add("Cache-Control", "no-cache");
+
+        var normalized = TraceContextHeadersNormalizer.normalizeResponseHeaders(responseHeaders);
+
+        assertTrue(normalized.containsKey(X_WOODY_TRACE_ID));
+        assertTrue(normalized.containsKey(X_WOODY_SPAN_ID));
+        assertTrue(normalized.containsKey(X_WOODY_PARENT_ID));
+        assertTrue(normalized.containsKey(X_WOODY_DEADLINE));
+        assertTrue(normalized.containsKey(X_WOODY_ERROR_CLASS));
+        assertTrue(normalized.containsKey(X_WOODY_ERROR_REASON));
+        assertTrue(normalized.containsKey(X_WOODY_META_USER_IDENTITY_PREFIX + "id"));
+        assertTrue(normalized.containsKey(OTEL_TRACE_PARENT));
+        assertTrue(normalized.containsKey(X_REQUEST_ID));
+        assertFalse(normalized.containsKey("Content-Type"));
+        assertFalse(normalized.containsKey("Cache-Control"));
+    }
+}

--- a/src/test/java/dev/vality/wachter/tracing/TraceContextHeadersNormalizerTest.java
+++ b/src/test/java/dev/vality/wachter/tracing/TraceContextHeadersNormalizerTest.java
@@ -296,8 +296,9 @@ class TraceContextHeadersNormalizerTest {
         responseHeaders.add(WOODY_SPAN_ID, "resp-span");
         responseHeaders.add(X_WOODY_PARENT_ID, "resp-parent");
         responseHeaders.add(WOODY_META_USER_IDENTITY_PREFIX + "id", "resp-user");
+        responseHeaders.add(WOODY_META_USER_IDENTITY_PREFIX + "x-request-id", "resp-req");
+        responseHeaders.add(WOODY_META_USER_IDENTITY_PREFIX + "x-request-deadline", "2030-01-01T00:00:00Z");
         responseHeaders.add(OTEL_TRACE_PARENT, "00-abc-def-01");
-        responseHeaders.add(X_REQUEST_ID, "resp-req");
         responseHeaders.add(WOODY_DEADLINE, "2030-01-01T00:00:00Z");
         responseHeaders.add(WOODY_ERROR_CLASS, "resp-req");
         responseHeaders.add(WOODY_ERROR_REASON, "resp-req");
@@ -313,8 +314,11 @@ class TraceContextHeadersNormalizerTest {
         assertTrue(normalized.containsKey(X_WOODY_ERROR_CLASS));
         assertTrue(normalized.containsKey(X_WOODY_ERROR_REASON));
         assertTrue(normalized.containsKey(X_WOODY_META_USER_IDENTITY_PREFIX + "id"));
+        assertTrue(normalized.containsKey(X_WOODY_META_USER_IDENTITY_PREFIX + "x-request-id"));
+        assertTrue(normalized.containsKey(X_WOODY_META_USER_IDENTITY_PREFIX + "x-request-deadline"));
         assertTrue(normalized.containsKey(OTEL_TRACE_PARENT));
         assertTrue(normalized.containsKey(X_REQUEST_ID));
+        assertTrue(normalized.containsKey(X_REQUEST_DEADLINE));
         assertFalse(normalized.containsKey("Content-Type"));
         assertFalse(normalized.containsKey("Cache-Control"));
     }

--- a/src/test/java/dev/vality/wachter/tracing/TraceContextPipelineTest.java
+++ b/src/test/java/dev/vality/wachter/tracing/TraceContextPipelineTest.java
@@ -1,0 +1,81 @@
+package dev.vality.wachter.tracing;
+
+import dev.vality.woody.api.flow.WFlow;
+import dev.vality.woody.api.trace.context.TraceContext;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static dev.vality.wachter.constants.TraceHeadersConstants.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class TraceContextPipelineTest {
+
+    private SdkTracerProvider tracerProvider;
+
+    @BeforeEach
+    void setUp() {
+        GlobalOpenTelemetry.resetForTest();
+        tracerProvider = SdkTracerProvider.builder().build();
+        var openTelemetry = OpenTelemetrySdk.builder()
+                .setTracerProvider(tracerProvider)
+                .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
+                .build();
+        GlobalOpenTelemetry.set(openTelemetry);
+    }
+
+    @AfterEach
+    void tearDown() {
+        TraceContext.setCurrentTraceData(null);
+        GlobalOpenTelemetry.resetForTest();
+        if (tracerProvider != null) {
+            tracerProvider.close();
+        }
+    }
+
+    @Test
+    void shouldRestoreAndExtractTraceContextWithinWFlow() {
+        var normalized = new HashMap<String, String>();
+        normalized.put(WOODY_TRACE_ID, "GZyWNGugAAA");
+        normalized.put(WOODY_SPAN_ID, "GZyWNGugBBB");
+        normalized.put(WOODY_PARENT_ID, "undefined");
+        normalized.put(WOODY_DEADLINE, "2030-01-01T00:00:00Z");
+        var otelTraceId = "3d8202ad198e4d37771c995246e1b356";
+        normalized.put(OTEL_TRACE_PARENT, "00-" + otelTraceId + "-9cfa814ae977266e-01");
+        normalized.put(WOODY_META_USER_IDENTITY_PREFIX + "id", "user-id");
+        normalized.put(WOODY_META_USER_IDENTITY_PREFIX + "username", "user-name");
+        normalized.put(WOODY_META_USER_IDENTITY_PREFIX + "email", "user@example.com");
+        normalized.put(WOODY_META_USER_IDENTITY_PREFIX + "realm", "/internal");
+        normalized.put(X_REQUEST_ID, "request-id");
+        normalized.put(X_REQUEST_DEADLINE, "2030-01-01T00:00:00Z");
+
+        var traceData = TraceContextRestorer.restoreTraceData(normalized);
+        var extractedRef = new AtomicReference<Map<String, String>>();
+
+        WFlow.create(() -> extractedRef.set(TraceContextHeadersExtractor.extractHeaders()), traceData).run();
+
+        var extracted = extractedRef.get();
+        assertNotNull(extracted);
+        assertEquals("GZyWNGugAAA", extracted.get(WOODY_TRACE_ID));
+        assertEquals("GZyWNGugBBB", extracted.get(WOODY_SPAN_ID));
+        assertEquals("undefined", extracted.get(WOODY_PARENT_ID));
+        assertEquals("2030-01-01T00:00:00Z", extracted.get(WOODY_DEADLINE));
+        assertEquals("user-id", extracted.get(WOODY_META_USER_IDENTITY_PREFIX + "id"));
+        assertEquals("user-name", extracted.get(WOODY_META_USER_IDENTITY_PREFIX + "username"));
+        assertEquals("user@example.com", extracted.get(WOODY_META_USER_IDENTITY_PREFIX + "email"));
+        assertEquals("/internal", extracted.get(WOODY_META_USER_IDENTITY_PREFIX + "realm"));
+        assertEquals("request-id", extracted.get(X_REQUEST_ID));
+        assertEquals("2030-01-01T00:00:00Z", extracted.get(X_REQUEST_DEADLINE));
+        assertTrue(extracted.get(OTEL_TRACE_PARENT).contains(otelTraceId));
+    }
+}

--- a/src/test/java/dev/vality/wachter/tracing/TraceContextPipelineTest.java
+++ b/src/test/java/dev/vality/wachter/tracing/TraceContextPipelineTest.java
@@ -73,8 +73,8 @@ class TraceContextPipelineTest {
         assertEquals("user-name", extracted.get(WOODY_META_USER_IDENTITY_PREFIX + "username"));
         assertEquals("user@example.com", extracted.get(WOODY_META_USER_IDENTITY_PREFIX + "email"));
         assertEquals("/internal", extracted.get(WOODY_META_USER_IDENTITY_PREFIX + "realm"));
-        assertEquals("request-id", extracted.get(X_REQUEST_ID));
-        assertEquals("2030-01-01T00:00:00Z", extracted.get(X_REQUEST_DEADLINE));
+        assertEquals("request-id", extracted.get(WOODY_META_REQUEST_ID));
+        assertEquals("2030-01-01T00:00:00Z", extracted.get(WOODY_META_REQUEST_DEADLINE));
         assertTrue(extracted.get(OTEL_TRACE_PARENT).contains(otelTraceId));
     }
 }

--- a/src/test/java/dev/vality/wachter/tracing/TraceContextPipelineTest.java
+++ b/src/test/java/dev/vality/wachter/tracing/TraceContextPipelineTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;

--- a/src/test/java/dev/vality/wachter/tracing/TraceContextRestorerTest.java
+++ b/src/test/java/dev/vality/wachter/tracing/TraceContextRestorerTest.java
@@ -74,16 +74,16 @@ class TraceContextRestorerTest {
         var headers = new HashMap<String, String>();
         headers.put(WOODY_TRACE_ID, "trace-123");
         headers.put(WOODY_META_USER_IDENTITY_PREFIX + "id", "b54a93c4-415d-4f33-a5e9-3608fd043ff4");
-        headers.put(WOODY_META_USER_IDENTITY_PREFIX + "username", "noreply@empayre.com");
-        headers.put(WOODY_META_USER_IDENTITY_PREFIX + "email", "noreply@empayre.com");
+        headers.put(WOODY_META_USER_IDENTITY_PREFIX + "username", "noreply@valitydev.com");
+        headers.put(WOODY_META_USER_IDENTITY_PREFIX + "email", "noreply@valitydev.com");
         headers.put(WOODY_META_USER_IDENTITY_PREFIX + "realm", "/internal");
 
         TraceData traceData = TraceContextRestorer.restoreTraceData(headers);
 
         var metadata = traceData.getActiveSpan().getCustomMetadata();
         assertEquals("b54a93c4-415d-4f33-a5e9-3608fd043ff4", metadata.getValue(UserIdentityIdExtensionKit.KEY));
-        assertEquals("noreply@empayre.com", metadata.getValue(UserIdentityUsernameExtensionKit.KEY));
-        assertEquals("noreply@empayre.com", metadata.getValue(UserIdentityEmailExtensionKit.KEY));
+        assertEquals("noreply@valitydev.com", metadata.getValue(UserIdentityUsernameExtensionKit.KEY));
+        assertEquals("noreply@valitydev.com", metadata.getValue(UserIdentityEmailExtensionKit.KEY));
         assertEquals("/internal", metadata.getValue(UserIdentityRealmExtensionKit.KEY));
         assertNotNull(traceData.getServiceSpan().getSpan().getTraceId());
         assertNotNull(traceData.getServiceSpan().getSpan().getId());

--- a/src/test/java/dev/vality/wachter/tracing/TraceContextRestorerTest.java
+++ b/src/test/java/dev/vality/wachter/tracing/TraceContextRestorerTest.java
@@ -1,0 +1,270 @@
+package dev.vality.wachter.tracing;
+
+import dev.vality.woody.api.trace.TraceData;
+import dev.vality.woody.api.trace.context.TraceContext;
+import dev.vality.woody.api.trace.context.metadata.user.UserIdentityEmailExtensionKit;
+import dev.vality.woody.api.trace.context.metadata.user.UserIdentityIdExtensionKit;
+import dev.vality.woody.api.trace.context.metadata.user.UserIdentityRealmExtensionKit;
+import dev.vality.woody.api.trace.context.metadata.user.UserIdentityUsernameExtensionKit;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+import static dev.vality.wachter.constants.TraceHeadersConstants.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class TraceContextRestorerTest {
+
+    private SdkTracerProvider tracerProvider;
+
+    @BeforeEach
+    void setUp() {
+        GlobalOpenTelemetry.resetForTest();
+        tracerProvider = SdkTracerProvider.builder().build();
+        var openTelemetry = OpenTelemetrySdk.builder()
+                .setTracerProvider(tracerProvider)
+                .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
+                .build();
+        GlobalOpenTelemetry.set(openTelemetry);
+    }
+
+    @AfterEach
+    void tearDown() {
+        TraceContext.setCurrentTraceData(null);
+        GlobalOpenTelemetry.resetForTest();
+        if (tracerProvider != null) {
+            tracerProvider.close();
+        }
+    }
+
+    @Test
+    void shouldRestoreWoodyTraceHeaders() {
+        var headers = Map.of(
+                WOODY_TRACE_ID, "GZyWNGugAAA",
+                WOODY_SPAN_ID, "GZyWNGugBBB",
+                WOODY_PARENT_ID, "undefined",
+                WOODY_DEADLINE, "2030-01-01T00:00:00Z"
+        );
+
+        TraceData traceData = TraceContextRestorer.restoreTraceData(headers);
+
+        assertNotNull(traceData);
+        var span = traceData.getServiceSpan().getSpan();
+        assertEquals("GZyWNGugAAA", span.getTraceId());
+        assertEquals("GZyWNGugBBB", span.getId());
+        assertEquals("undefined", span.getParentId());
+        assertEquals(Instant.parse("2030-01-01T00:00:00Z"), span.getDeadline());
+        assertNotNull(traceData.getServiceSpan().getSpan().getTraceId());
+        assertNotNull(traceData.getServiceSpan().getSpan().getId());
+        assertTrue(traceData.getOtelSpan().getSpanContext().isValid());
+        assertNotNull(traceData.getOtelSpan().getSpanContext().getTraceId());
+    }
+
+    @Test
+    void shouldRestoreUserIdentityMetadata() {
+        var headers = new HashMap<String, String>();
+        headers.put(WOODY_TRACE_ID, "trace-123");
+        headers.put(WOODY_META_USER_IDENTITY_PREFIX + "id", "b54a93c4-415d-4f33-a5e9-3608fd043ff4");
+        headers.put(WOODY_META_USER_IDENTITY_PREFIX + "username", "noreply@empayre.com");
+        headers.put(WOODY_META_USER_IDENTITY_PREFIX + "email", "noreply@empayre.com");
+        headers.put(WOODY_META_USER_IDENTITY_PREFIX + "realm", "/internal");
+
+        TraceData traceData = TraceContextRestorer.restoreTraceData(headers);
+
+        var metadata = traceData.getActiveSpan().getCustomMetadata();
+        assertEquals("b54a93c4-415d-4f33-a5e9-3608fd043ff4", metadata.getValue(UserIdentityIdExtensionKit.KEY));
+        assertEquals("noreply@empayre.com", metadata.getValue(UserIdentityUsernameExtensionKit.KEY));
+        assertEquals("noreply@empayre.com", metadata.getValue(UserIdentityEmailExtensionKit.KEY));
+        assertEquals("/internal", metadata.getValue(UserIdentityRealmExtensionKit.KEY));
+        assertNotNull(traceData.getServiceSpan().getSpan().getTraceId());
+        assertNotNull(traceData.getServiceSpan().getSpan().getId());
+        assertTrue(traceData.getOtelSpan().getSpanContext().isValid());
+        assertNotNull(traceData.getOtelSpan().getSpanContext().getTraceId());
+    }
+
+    @Test
+    void shouldRestoreRequestMetadata() {
+        var headers = Map.of(
+                WOODY_TRACE_ID, "trace-123",
+                X_REQUEST_ID, "req-456",
+                X_REQUEST_DEADLINE, "2030-12-31T23:59:59Z"
+        );
+
+        TraceData traceData = TraceContextRestorer.restoreTraceData(headers);
+
+        var metadata = traceData.getActiveSpan().getCustomMetadata();
+        assertEquals("req-456", metadata.getValue(X_REQUEST_ID));
+        assertEquals("2030-12-31T23:59:59Z", metadata.getValue(X_REQUEST_DEADLINE));
+        assertNotNull(traceData.getServiceSpan().getSpan().getTraceId());
+        assertNotNull(traceData.getServiceSpan().getSpan().getId());
+        assertTrue(traceData.getOtelSpan().getSpanContext().isValid());
+        assertNotNull(traceData.getOtelSpan().getSpanContext().getTraceId());
+    }
+
+    @Test
+    void shouldRestoreTraceparentAndCreateOtelSpan() {
+        var traceId = "cfa3d3072a4e3e99fc14829a65311819";
+        var headers = Map.of(
+                WOODY_TRACE_ID, "trace-123",
+                OTEL_TRACE_PARENT, "00-" + traceId + "-6e4609576fa4d077-01"
+        );
+
+        TraceData traceData = TraceContextRestorer.restoreTraceData(headers);
+
+        assertEquals(traceId, traceData.getOtelSpan().getSpanContext().getTraceId());
+        assertNotNull(traceData.getServiceSpan().getSpan().getTraceId());
+        assertNotNull(traceData.getServiceSpan().getSpan().getId());
+        assertTrue(traceData.getOtelSpan().getSpanContext().isValid());
+        assertNotNull(traceData.getOtelSpan().getSpanContext().getTraceId());
+    }
+
+    @Test
+    void shouldHandleEmptyHeaders() {
+        TraceData traceData = TraceContextRestorer.restoreTraceData(Map.of());
+
+        assertNotNull(traceData.getServiceSpan().getSpan().getTraceId());
+        assertNotNull(traceData.getServiceSpan().getSpan().getId());
+        assertTrue(traceData.getOtelSpan().getSpanContext().isValid());
+        assertNotNull(traceData.getOtelSpan().getSpanContext().getTraceId());
+    }
+
+    @Test
+    void shouldHandlePartialHeaders() {
+        var headers = Map.of(
+                WOODY_TRACE_ID, "trace-123"
+        );
+
+        TraceData traceData = TraceContextRestorer.restoreTraceData(headers);
+
+        assertEquals("trace-123", traceData.getServiceSpan().getSpan().getTraceId());
+        assertNull(traceData.getServiceSpan().getSpan().getDeadline());
+        assertNotNull(traceData.getServiceSpan().getSpan().getTraceId());
+        assertNotNull(traceData.getServiceSpan().getSpan().getId());
+        assertTrue(traceData.getOtelSpan().getSpanContext().isValid());
+        assertNotNull(traceData.getOtelSpan().getSpanContext().getTraceId());
+    }
+
+    @Test
+    void shouldHandleInvalidDeadline() {
+        var headers = Map.of(
+                WOODY_TRACE_ID, "trace-123",
+                WOODY_DEADLINE, "invalid-date"
+        );
+
+        TraceData traceData = TraceContextRestorer.restoreTraceData(headers);
+
+        assertEquals("trace-123", traceData.getServiceSpan().getSpan().getTraceId());
+        assertNull(traceData.getServiceSpan().getSpan().getDeadline());
+        assertNotNull(traceData.getServiceSpan().getSpan().getTraceId());
+        assertNotNull(traceData.getServiceSpan().getSpan().getId());
+        assertTrue(traceData.getOtelSpan().getSpanContext().isValid());
+        assertNotNull(traceData.getOtelSpan().getSpanContext().getTraceId());
+    }
+
+    @Test
+    void shouldHandleComplexScenarioWithAllData() {
+        var headers = new HashMap<String, String>();
+        headers.put(WOODY_TRACE_ID, "GZvsthKQAAA");
+        headers.put(WOODY_SPAN_ID, "GZvsthKQBBB");
+        headers.put(WOODY_PARENT_ID, "parent-123");
+        headers.put(WOODY_DEADLINE, "2030-06-15T12:30:00Z");
+        var otelTraceId = "3d8202ad198e4d37771c995246e1b356";
+        headers.put(OTEL_TRACE_PARENT, "00-" + otelTraceId + "-9cfa814ae977266e-01");
+        headers.put(WOODY_META_USER_IDENTITY_PREFIX + "id", "user-uuid");
+        headers.put(WOODY_META_USER_IDENTITY_PREFIX + "username", "john.doe");
+        headers.put(WOODY_META_USER_IDENTITY_PREFIX + "email", "john@example.com");
+        headers.put(WOODY_META_USER_IDENTITY_PREFIX + "realm", "/external");
+        headers.put(X_REQUEST_ID, "complex-request-id");
+        headers.put(X_REQUEST_DEADLINE, "2030-06-15T13:00:00Z");
+
+        TraceData traceData = TraceContextRestorer.restoreTraceData(headers);
+
+        var span = traceData.getServiceSpan().getSpan();
+        assertEquals("GZvsthKQAAA", span.getTraceId());
+        assertEquals("GZvsthKQBBB", span.getId());
+        assertEquals("parent-123", span.getParentId());
+        assertEquals(Instant.parse("2030-06-15T12:30:00Z"), span.getDeadline());
+
+        var metadata = traceData.getActiveSpan().getCustomMetadata();
+        assertEquals("user-uuid", metadata.getValue(UserIdentityIdExtensionKit.KEY));
+        assertEquals("john.doe", metadata.getValue(UserIdentityUsernameExtensionKit.KEY));
+        assertEquals("john@example.com", metadata.getValue(UserIdentityEmailExtensionKit.KEY));
+        assertEquals("/external", metadata.getValue(UserIdentityRealmExtensionKit.KEY));
+        assertEquals("complex-request-id", metadata.getValue(X_REQUEST_ID));
+        assertEquals("2030-06-15T13:00:00Z", metadata.getValue(X_REQUEST_DEADLINE));
+
+        assertEquals(otelTraceId, traceData.getOtelSpan().getSpanContext().getTraceId());
+        assertNotNull(traceData.getServiceSpan().getSpan().getTraceId());
+        assertNotNull(traceData.getServiceSpan().getSpan().getId());
+        assertTrue(traceData.getOtelSpan().getSpanContext().isValid());
+        assertNotNull(traceData.getOtelSpan().getSpanContext().getTraceId());
+    }
+
+    @Test
+    void shouldHandleNullAndEmptyValues() {
+        var headers = new HashMap<String, String>();
+        headers.put(WOODY_TRACE_ID, "trace-123");
+        headers.put(WOODY_SPAN_ID, "");
+        headers.put(WOODY_PARENT_ID, null);
+        headers.put(WOODY_META_USER_IDENTITY_PREFIX + "id", "");
+        headers.put(WOODY_META_USER_IDENTITY_PREFIX + "username", null);
+
+        TraceData traceData = TraceContextRestorer.restoreTraceData(headers);
+
+        var span = traceData.getServiceSpan().getSpan();
+        assertEquals("trace-123", span.getTraceId());
+        assertNotNull(span.getId());
+        assertNotNull(span.getParentId());
+
+        var metadata = traceData.getActiveSpan().getCustomMetadata();
+        assertNull(metadata.getValue(UserIdentityIdExtensionKit.KEY));
+        assertNull(metadata.getValue(UserIdentityUsernameExtensionKit.KEY));
+        assertNotNull(traceData.getServiceSpan().getSpan().getTraceId());
+        assertNotNull(traceData.getServiceSpan().getSpan().getId());
+        assertTrue(traceData.getOtelSpan().getSpanContext().isValid());
+        assertNotNull(traceData.getOtelSpan().getSpanContext().getTraceId());
+    }
+
+    @Test
+    void shouldHandleInvalidTraceparentGracefully() {
+        var headers = Map.of(
+                WOODY_TRACE_ID, "trace-123",
+                OTEL_TRACE_PARENT, "invalid-traceparent"
+        );
+
+        TraceData traceData = TraceContextRestorer.restoreTraceData(headers);
+
+        assertEquals("trace-123", traceData.getServiceSpan().getSpan().getTraceId());
+        assertNotNull(traceData.getServiceSpan().getSpan().getTraceId());
+        assertNotNull(traceData.getServiceSpan().getSpan().getId());
+        assertTrue(traceData.getOtelSpan().getSpanContext().isValid());
+        assertNotNull(traceData.getOtelSpan().getSpanContext().getTraceId());
+    }
+
+    @Test
+    void shouldRestoreMetadataWithSpecialCharacters() {
+        var headers = new HashMap<String, String>();
+        headers.put(WOODY_TRACE_ID, "trace-123");
+        headers.put(WOODY_META_USER_IDENTITY_PREFIX + "username", "user@domain.com");
+        headers.put(WOODY_META_USER_IDENTITY_PREFIX + "email", "user+test@domain.com");
+        headers.put(WOODY_META_USER_IDENTITY_PREFIX + "realm", "/realm/with/slashes");
+        headers.put(X_REQUEST_ID, "req-with-dashes-123");
+
+        TraceData traceData = TraceContextRestorer.restoreTraceData(headers);
+
+        var metadata = traceData.getActiveSpan().getCustomMetadata();
+        assertEquals("user@domain.com", metadata.getValue(UserIdentityUsernameExtensionKit.KEY));
+        assertEquals("user+test@domain.com", metadata.getValue(UserIdentityEmailExtensionKit.KEY));
+        assertEquals("/realm/with/slashes", metadata.getValue(UserIdentityRealmExtensionKit.KEY));
+        assertEquals("req-with-dashes-123", metadata.getValue(X_REQUEST_ID));
+    }
+}

--- a/src/test/java/dev/vality/wachter/tracing/WoodyTracingFilterTest.java
+++ b/src/test/java/dev/vality/wachter/tracing/WoodyTracingFilterTest.java
@@ -1,6 +1,5 @@
-package dev.vality.wachter.config.tracing;
+package dev.vality.wachter.tracing;
 
-import dev.vality.wachter.tracing.WoodyTracingFilter;
 import dev.vality.woody.api.trace.context.TraceContext;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
@@ -15,8 +14,9 @@ import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
-import static dev.vality.wachter.constants.TraceHeadersConstants.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static dev.vality.wachter.constants.TraceHeadersConstants.X_WOODY_SPAN_ID;
+import static dev.vality.wachter.constants.TraceHeadersConstants.X_WOODY_TRACE_ID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class WoodyTracingFilterTest {
 


### PR DESCRIPTION
1 тесты - в response возвращал то что не надо (502)
2 тесты - в request не клал то что надо (500 из за отстувия application/thrift) 

еще перерефакторил что перестали метаданные отправляться в апстрим

теперь и то и то есть

Описание
Между 826384d3 и 2594b858 прокси-клиент научили собирать нужные заголовки запроса через новый экстрактор, объединять их с
   трейс-метаданными и отдавать апстриму, одновременно отсекая шум, чтобы заголовки контентных переговоров доходили без потерь.
   Константы и нормализаторы трейсинга расширены: Woody-метаданные теперь содержат X-Request-* в пространстве
   woody.meta.user-identity, но при этом возвращают их наружу как прежние X-Request-ID и X-Request-Deadline. Сборка обновлена
   (версия проекта 1.0.0, новая WireMock-зависимость), а Keycloak-стабы подправлены; тесты пополнились проверками проксирования
   заголовков, нормализации трейсинга и обработки ответов.